### PR TITLE
Querystring building is incorrect in SolrConnection

### DIFF
--- a/SolrNet/Impl/SolrConnection.cs
+++ b/SolrNet/Impl/SolrConnection.cs
@@ -117,7 +117,7 @@ namespace SolrNet.Impl {
             if (parameters != null)
                 param.AddRange(parameters);
             param.Add(KVP("version", version));
-            u.Query = "?" + string.Join("&", param
+            u.Query = string.Join("&", param
                 .Select(kv => KVP(HttpUtility.UrlEncode(kv.Key), HttpUtility.UrlEncode(kv.Value)))
                 .Select(kv => string.Format("{0}={1}", kv.Key, kv.Value))
                 .ToArray());


### PR DESCRIPTION
The query builder which composes GET parameters was adding a leading "?" to requests, and this resulted in two question marks at the start of a get request, and these are were being resolved incorrectly by Solr. For example it would generate: 

```
??q=*%3a*&start=0&rows=5&spellcheck=true&facet=true&facet.field=cat&f.cat.facet.mincount=1&facet.field=manu_exact&f.manu_exact.facet.mincount=1&version=2.2
```

And Solr would interpret this as 

```
spellcheck=true&?q=*%3a*&start=0&rows=5&facet=true&facet.field=cat&f.cat.facet.mincount=1&facet.field=manu_exact&f.manu_exact.facet.mincount=1&version=2.2
```

(The order is changed in the Solr logs, I imagine it re-orders something internally)

Notice the leading questionmark before `q` in the interpreted parameters. Removing the leading question mark in the Solr connection ensures a correct parameter string is generated and interpreted correctly
