### PR TITLE
0.3.x - issue 159: ignore LocalParams for facet date parameters (qv issue 133)

### DIFF
--- a/SolrNet/Impl/FacetQuerySerializers/SolrFacetDateQuerySerializer.cs
+++ b/SolrNet/Impl/FacetQuerySerializers/SolrFacetDateQuerySerializer.cs
@@ -16,10 +16,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using SolrNet.Utils;
 
 namespace SolrNet.Impl.FacetQuerySerializers {
     public class SolrFacetDateQuerySerializer : SingleTypeFacetQuerySerializer<SolrFacetDateQuery> {
+
+        private static readonly Regex localParamsRx = new Regex(@"\{![^\}]+\}", RegexOptions.Compiled);
 
         private readonly ISolrFieldSerializer fieldSerializer;
 
@@ -36,15 +39,16 @@ namespace SolrNet.Impl.FacetQuerySerializers {
         }
 
         public override IEnumerable<KeyValuePair<string, string>> Serialize(SolrFacetDateQuery q) {
+            var fieldWithoutLocalParams = localParamsRx.Replace(q.Field, ""); 
             yield return KV("facet.date", q.Field);
-            yield return KV(string.Format("f.{0}.facet.date.start", q.Field), SerializeSingle(q.Start));
-            yield return KV(string.Format("f.{0}.facet.date.end", q.Field), SerializeSingle(q.End));
-            yield return KV(string.Format("f.{0}.facet.date.gap", q.Field), q.Gap);
+            yield return KV(string.Format("f.{0}.facet.date.start", fieldWithoutLocalParams), SerializeSingle(q.Start));
+            yield return KV(string.Format("f.{0}.facet.date.end", fieldWithoutLocalParams), SerializeSingle(q.End));
+            yield return KV(string.Format("f.{0}.facet.date.gap", fieldWithoutLocalParams), q.Gap);
             if (q.HardEnd.HasValue)
-                yield return KV(string.Format("f.{0}.facet.date.hardend", q.Field), SerializeSingle(q.HardEnd.Value));
+                yield return KV(string.Format("f.{0}.facet.date.hardend", fieldWithoutLocalParams), SerializeSingle(q.HardEnd.Value));
             if (q.Other != null && q.Other.Count > 0)
                 foreach (var o in q.Other)
-                    yield return KV(string.Format("f.{0}.facet.date.other", q.Field), o.ToString());
+                    yield return KV(string.Format("f.{0}.facet.date.other", fieldWithoutLocalParams), o.ToString());
         }
     }
 }

--- a/SolrNet/SolrFacetDateQuery.cs
+++ b/SolrNet/SolrFacetDateQuery.cs
@@ -81,19 +81,5 @@ namespace SolrNet {
         public string Gap {
             get { return gap; }
         }
-
-        public IEnumerable<KeyValuePair<string, string>> Query {
-            get {
-                yield return KV("facet.date", field);
-                yield return KV(string.Format("f.{0}.facet.date.start", field), dateSerializer.SerializeDate(start));
-                yield return KV(string.Format("f.{0}.facet.date.end", field), dateSerializer.SerializeDate(end));
-                yield return KV(string.Format("f.{0}.facet.date.gap", field), gap);
-                if (HardEnd.HasValue)
-                    yield return KV(string.Format("f.{0}.facet.date.hardend", field), boolSerializer.SerializeBool(HardEnd.Value));
-                if (Other != null && Other.Count > 0)
-                    foreach (var o in Other)
-                        yield return KV(string.Format("f.{0}.facet.date.other", field), o.ToString());
-            }
-        }
     }
 }


### PR DESCRIPTION
Hi Mauricio,

How exciting - my first dip into Git and open source contributions! Minor amendment to the FacetDate serializer, cribbed from issue 133, to support date faceting with local params.

Also included associated unit test, plus removed a rogue-looking property on the SolrFacetDateQuery object that seemed to be used by only unit test code...

Hopefully I've done all this right - it's my first time after all. I've only made the change on the 0.3.x branch, and am assuming you'll want to pull it into your 0.3.x branch and then merge from there up to master. But if you'd like me to make the same change in master, just let me know.

Thanks! Tom
