### PR TITLE
Added support for terms.

### DIFF
--- a/Castle.Facilities.SolrNetIntegration.Tests/Tests.cs
+++ b/Castle.Facilities.SolrNetIntegration.Tests/Tests.cs
@@ -127,7 +127,7 @@ namespace Castle.Facilities.SolrNetIntegration.Tests {
             var parser = container.Resolve<ISolrQueryResultParser<Document>>() as SolrQueryResultParser<Document>;
             var field = parser.GetType().GetField("parsers", BindingFlags.NonPublic | BindingFlags.Instance);
             var parsers = (ISolrResponseParser<Document>[]) field.GetValue(parser);
-            Assert.AreEqual(10, parsers.Length);
+            Assert.AreEqual(11, parsers.Length);
             foreach (var t in parsers)
                 Console.WriteLine(t);            
         }

--- a/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
+++ b/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
@@ -88,7 +88,8 @@ namespace Castle.Facilities.SolrNetIntegration {
                 typeof (StatsResponseParser<>),
                 typeof (CollapseResponseParser<>),
                 typeof(GroupingResponseParser<>),
-                typeof(ClusterResponseParser<>)
+                typeof(ClusterResponseParser<>),
+                typeof(TermsResponseParser<>)
             }) {
                 Kernel.Register(Component.For(typeof (ISolrResponseParser<>)).ImplementedBy(parserType));
             }

--- a/SolrNet.Tests/Resources/responseWithTerms.xml
+++ b/SolrNet.Tests/Resources/responseWithTerms.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="terms">
+    <lst name="text">
+      <int name="boot">479</int>
+      <int name="booti">13</int>
+    </lst>
+    <lst name="textgen">
+      <int name="boots">463</int>
+      <int name="boot">215</int>
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -245,6 +245,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\responseWithClustering.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithTerms.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SolrNet.Tests/SolrQueryExecuterTests.cs
+++ b/SolrNet.Tests/SolrQueryExecuterTests.cs
@@ -312,6 +312,48 @@ namespace SolrNet.Tests {
         }
 
         [Test]
+        public void Terms()
+        {
+            var mocks = new MockRepository();
+            var parser = mocks.DynamicMock<ISolrQueryResultParser<TestDocument>>();
+            var conn = mocks.DynamicMock<ISolrConnection>();
+            var queryExecuter = new SolrQueryExecuter<TestDocument>(parser, conn, null, null);
+            var p = queryExecuter.GetTermsParameters(new QueryOptions
+            {
+                Terms = new TermsParameters
+                {
+                    Field = "text",
+                    Limit = 10,
+                    Lower = "lower",
+                    LowerInclude = true,
+                    MaxCount = 10,
+                    MinCount = 0,
+                    Prefix = "pre",
+                    Raw = true,
+                    Regex = "regex",
+                    RegexFlag = new List<string>{ RegexFlags.CanonEq, RegexFlags.CaseInsensitive },
+                    Sort = "count",
+                    Upper = "upper",
+                    UpperInclude = true
+                },
+            }).ToList();
+            Assert.Contains(p, KVP("terms", "true"));
+            Assert.Contains(p, KVP("terms.fl", "text"));
+            Assert.Contains(p, KVP("terms.lower", "lower"));
+            Assert.Contains(p, KVP("terms.lower.incl", "true"));
+            Assert.Contains(p, KVP("terms.maxcount", "10"));
+            Assert.Contains(p, KVP("terms.mincount", "0"));
+            Assert.Contains(p, KVP("terms.prefix", "pre"));
+            Assert.Contains(p, KVP("terms.raw", "true"));
+            Assert.Contains(p, KVP("terms.regex", "regex"));
+            Assert.Contains(p, KVP("terms.regex.flag", RegexFlags.CanonEq));
+            Assert.Contains(p, KVP("terms.regex.flag", RegexFlags.CaseInsensitive));
+            Assert.Contains(p, KVP("terms.sort", "count"));
+            Assert.Contains(p, KVP("terms.upper", "upper"));
+            Assert.Contains(p, KVP("terms.upper.incl", "true"));
+        }
+
+        [Test]
         public void GetAllParameters_with_spelling() {
             var mocks = new MockRepository();
             var parser = mocks.DynamicMock<ISolrQueryResultParser<TestDocument>>();

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -515,6 +515,23 @@ namespace SolrNet.Tests {
         }
 
         [Test]
+        public void ParseTerms()
+        {
+            var parser = new TermsResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTerms.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='terms']");
+            var terms = parser.ParseTerms(docNode);
+            Assert.IsNotNull(terms);
+            Assert.AreEqual(2, terms.Count);
+            Assert.AreEqual("text", terms.First().Field);
+            Assert.AreEqual("textgen", terms.ElementAt(1).Field);
+            Assert.AreEqual("boot", terms.First().Terms.First().Key);
+            Assert.AreEqual(479, terms.First().Terms.First().Value);
+            Assert.AreEqual("boots", terms.ElementAt(1).Terms.First().Key);
+            Assert.AreEqual(463, terms.ElementAt(1).Terms.First().Value);
+        }
+
+        [Test]
         public void ParseMoreLikeThis() {
             var mapper = new AttributesMappingManager();
             var parser = new MoreLikeThisResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));

--- a/SolrNet/Commands/Parameters/QueryOptions.cs
+++ b/SolrNet/Commands/Parameters/QueryOptions.cs
@@ -62,6 +62,11 @@ namespace SolrNet.Commands.Parameters {
         public SpellCheckingParameters SpellCheck { get; set; }
 
         /// <summary>
+        /// Terms parameters
+        /// </summary>
+        public TermsParameters Terms { get; set; }
+
+        /// <summary>
         /// More-like-this parameters
         /// </summary>
         public MoreLikeThisParameters MoreLikeThis { get; set; }

--- a/SolrNet/Commands/Parameters/TermsParameters.cs
+++ b/SolrNet/Commands/Parameters/TermsParameters.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+
+namespace SolrNet.Commands.Parameters {
+
+    /// <summary>
+    /// Constants for the choices of Regex Flags 
+    /// </summary>
+    public class RegexFlags
+    {
+        public const string CaseInsensitive = "case_insensitive";
+        public const string Comments = "comments";
+        public const string MultiLine = "multiline";
+        public const string Literal = "literal";
+        public const string Multiline = "multiline";
+        public const string DotAll = "dotall";
+        public const string UnicodeCase = "unicode_case";
+        public const string CanonEq = "canon_eq";
+        public const string UnixLines = "unix_lines";
+    }
+
+    /// <summary>
+    /// Spell checking parameters
+    /// </summary>
+    public class TermsParameters {
+
+        /// <summary>
+        /// The field to get the terms from
+        /// terms.fl={FIELD NAME} - Required. The name of the field to get the terms from.
+        /// </summary>
+        public string Field { get; set; }
+
+        /// <summary>
+        /// Lower bound term to start at.
+        /// terms.lower={The lower bound term} - Optional. The term to start at. If not specified, the empty string is used, meaning start at the beginning of the field.
+        /// </summary>
+        public string Lower { get; set; }
+        
+        /// <summary>
+        /// terms.lower.incl={true|false} - Optional. Include the lower bound term in the result set. Default is true.
+        /// </summary>
+        public bool? LowerInclude { get; set;}
+
+        /// <summary>
+        /// terms.upper={The upper bound term} - The term to stop at. Either upper or terms.limit must be set.
+        /// </summary>
+        public string Upper { get; set; }
+
+        /// <summary>
+        /// terms.upper.incl={true|false} - Include the upper bound term in the result set. Default is false.
+        /// </summary>
+        public bool? UpperInclude { get; set; }
+
+        /// <summary>
+        /// terms.mincount=Integer - Optional. The minimum doc frequency to return in order to be included. Results are inclusive of the mincount (i.e. >= mincount)
+        /// </summary>
+        public int? MinCount { get; set; }
+
+        /// <summary>
+        /// terms.maxcount=Integer - Optional. The maximum doc frequency. Default is -1 to have no upper bound. Results are inclusive of the maxcount (i.e. less than maxcount)
+        /// </summary>
+        public int? MaxCount { get; set;} 
+
+        /// <summary>
+        /// Use this for implementing AutoComplete!
+        /// terms.prefix={String} - Optional. Restrict matches to terms that start with the prefix.
+        /// </summary>
+        public string Prefix { get; set; }
+
+        /// <summary>
+        /// terms.regex={String} - Optional. Restrict matches to terms that match the regular expression.  Solr3.1
+        /// </summary>
+        public string Regex { get; set; }
+         
+        /// <summary>
+        /// terms.regex.flag={case_insensitive|comments|multiline|literal|dotall|unicode_case|canon_eq|unix_lines} - Optional. 
+        /// Flags to be used when evaluating the regular expression defined in the "terms.regex" parameter (see http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/Pattern.html#compile%28java.lang.String,%20int%29 fore more details). 
+        /// This parameter can be defined multiple times (each time with different flag)  Solr3.1
+        /// TODO: Make this an array to allow for mutliple selections
+        /// </summary>
+        public List<string> RegexFlag { get; set; }       
+
+        /// <summary>
+        /// terms.limit={integer} - The maximum number of terms to return. The default is 10. If less than 0, then include all terms.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// terms.raw={true|false} - If true, return the raw characters of the indexed term, regardless of if it is human readable. For instance, the indexed form of numeric numbers is not human readable. The default is false.
+        /// </summary>
+        public bool? Raw { get; set; }
+
+        /// <summary>
+        /// terms.sort={count|index} - If count, sorts the terms by the term frequency (highest count first). If index, returns the terms in index order. Default is to sort by count.
+        /// </summary>
+        public string Sort { get; set; }
+       
+    }
+}

--- a/SolrNet/ISolrQueryResults.cs
+++ b/SolrNet/ISolrQueryResults.cs
@@ -93,5 +93,9 @@ namespace SolrNet {
         /// </summary>
         ClusterResults Clusters { get; set; }
 
+        /// <summary>
+        /// Term Results
+        /// </summary>
+        TermsResults Terms { get; set; }
 	}
 }

--- a/SolrNet/Impl/ResponseParsers/TermsResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/TermsResponseParser.cs
@@ -1,0 +1,58 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace SolrNet.Impl.ResponseParsers {
+    /// <summary>
+    /// Parses spell-checking results from a query response
+    /// </summary>
+    /// <typeparam name="T">Document type</typeparam>
+    public class TermsResponseParser<T> : ISolrResponseParser<T> {
+        public void Parse(XDocument xml, SolrQueryResults<T> results) {
+            var termsNode = xml.XPathSelectElement("response/lst[@name='terms']");
+            if (termsNode != null)
+                results.Terms = ParseTerms(termsNode);
+        }
+
+        /// <summary>
+        /// Parses spell-checking results
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public TermsResults ParseTerms(XElement node)
+        {
+            var r = new TermsResults();
+            var terms = node.Elements("lst");
+            foreach (var c in terms) {
+                var result = new TermsResult();
+                result.Field = c.Attribute("name").Value;
+                var termList = new List<KeyValuePair<string, int>>();
+                var termNodes = c.XPathSelectElements("int");
+                foreach (var termNode in termNodes) {
+                    termList.Add(new KeyValuePair<string, int>(termNode.Attribute("name").Value, int.Parse(termNode.Value)));
+                }
+                result.Terms = termList;
+                r.Add(result);
+            }
+            return r;
+        }
+    }
+}

--- a/SolrNet/Impl/SolrQueryExecuter.cs
+++ b/SolrNet/Impl/SolrQueryExecuter.cs
@@ -88,6 +88,9 @@ namespace SolrNet.Impl {
                 foreach (var p in GetSpellCheckingParameters(Options))
                     yield return p;
 
+                foreach (var p in GetTermsParameters(Options))
+                    yield return p;
+
                 foreach (var p in GetMoreLikeThisParameters(Options))
                     yield return p;
 
@@ -413,6 +416,49 @@ namespace SolrNet.Impl {
                 yield return KVP("carrot.outputSubClusters", clst.SubClusters.ToString().ToLowerInvariant());
             if (clst.LexicalResources != null)
                 yield return KVP("carrot.lexicalResourcesDir", clst.LexicalResources.ToString());
+        }
+
+        /// <summary>
+        /// Gets solr parameters for terms component
+        /// </summary>
+        /// <param name="Options"></param>
+        /// <returns></returns>
+        public IEnumerable<KeyValuePair<string, string>> GetTermsParameters(QueryOptions Options)
+        {
+            var terms = Options.Terms;
+            if (terms != null)
+            {
+                if (!string.IsNullOrEmpty(terms.Field))
+                {
+                    yield return KVP("terms", "true");
+                    yield return KVP("terms.fl", terms.Field);
+                }   
+                if (!string.IsNullOrEmpty(terms.Prefix))
+                    yield return KVP("terms.prefix", terms.Prefix);
+                if (!string.IsNullOrEmpty(terms.Sort))
+                    yield return KVP("terms.sort", terms.Sort);
+                if (terms.Limit.HasValue)
+                    yield return KVP("terms.limit", terms.Limit.ToString());
+                if (!string.IsNullOrEmpty(terms.Lower))
+                    yield return KVP("terms.lower", terms.Lower);
+                if (terms.LowerInclude.HasValue)
+                    yield return KVP("terms.lower.incl", terms.LowerInclude.ToString().ToLowerInvariant());
+                if (!string.IsNullOrEmpty(terms.Upper))
+                    yield return KVP("terms.upper", terms.Upper);
+                if (terms.UpperInclude.HasValue)
+                    yield return KVP("terms.upper.incl", terms.UpperInclude.ToString().ToLowerInvariant());
+                if (terms.MaxCount.HasValue)
+                    yield return KVP("terms.maxcount", terms.MaxCount.ToString());
+                if (terms.MinCount.HasValue)
+                    yield return KVP("terms.mincount", terms.MinCount.ToString());
+                if (terms.Raw.HasValue)
+                    yield return KVP("terms.raw", terms.Raw.ToString().ToLowerInvariant());
+                if (!string.IsNullOrEmpty(terms.Regex))
+                    yield return KVP("terms.regex", terms.Regex);
+                if (terms.RegexFlag != null && terms.RegexFlag.Any())
+                    foreach (string flag in terms.RegexFlag)
+                        yield return KVP("terms.regex.flag", flag);
+            }
         }
 
         /// <summary>

--- a/SolrNet/Impl/SolrQueryResults.cs
+++ b/SolrNet/Impl/SolrQueryResults.cs
@@ -190,6 +190,7 @@ namespace SolrNet.Impl {
         public IDictionary<string, StatsResult> Stats { get; set; }
         public CollapseResults Collapsing { get; set; }
         public ClusterResults Clusters { get; set; }
+        public TermsResults Terms { get; set; }
 
 
 		public IDictionary<string, GroupedResults<T>> Grouping { set; get; }
@@ -216,6 +217,7 @@ namespace SolrNet.Impl {
             Collapsing = new CollapseResults();
 			//Grouping = new GroupedResults<T>();
 			Grouping = new Dictionary<string, GroupedResults<T>>();
+            Terms = new TermsResults();
         }
 	}
 }

--- a/SolrNet/Impl/TermsResult.cs
+++ b/SolrNet/Impl/TermsResult.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace SolrNet.Impl {
+    /// <summary>
+    /// Terms Results
+    /// </summary>
+    public class TermsResult {
+        /// <summary>
+        /// terms field
+        /// </summary>
+        public string Field { get; set;}
+
+        /// <summary>
+        /// Spelling suggestions
+        /// </summary>
+        public ICollection<KeyValuePair<string,int>> Terms { get; set; }
+    }
+}

--- a/SolrNet/Impl/TermsResults.cs
+++ b/SolrNet/Impl/TermsResults.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace SolrNet.Impl {
+    /// <summary>
+    /// Terms results
+    /// </summary>
+    public class TermsResults : ICollection<TermsResult> {
+        /// <summary>
+        /// Terms results
+        /// </summary>
+
+        private readonly ICollection<TermsResult> Terms = new List<TermsResult>();
+
+        public IEnumerator<TermsResult> GetEnumerator() {
+            return Terms.GetEnumerator();
+        }
+
+        public void Add(TermsResult item) {
+            Terms.Add(item);
+        }
+
+        public void Clear() {
+            Terms.Clear();
+        }
+
+        public bool Contains(TermsResult item) {
+            return Terms.Contains(item);
+        }
+
+        public void CopyTo(TermsResult[] array, int arrayIndex) {
+            Terms.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(TermsResult item) {
+            return Terms.Remove(item);
+        }
+
+        public int Count {
+            get { return Terms.Count; }
+        }
+
+        public bool IsReadOnly {
+            get { return Terms.IsReadOnly; }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+    }
+}

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -70,6 +70,7 @@
     <Compile Include="AbstractSolrQuery.cs" />
     <Compile Include="ClusterResults.cs" />
     <Compile Include="Commands\Parameters\ClusteringParameters.cs" />
+    <Compile Include="Commands\Parameters\TermsParameters.cs" />
     <Compile Include="Commands\Parameters\GroupingParameters.cs" />
     <Compile Include="ExtractParameters.cs" />
     <Compile Include="AddParameters.cs" />
@@ -87,9 +88,12 @@
     <Compile Include="Commands\RollbackCommand.cs" />
     <Compile Include="DateFacetingResult.cs" />
     <Compile Include="GroupedResults.cs" />
+    <Compile Include="Impl\TermsResults.cs" />
+    <Compile Include="Impl\TermsResult.cs" />
     <Compile Include="Impl\FacetQuerySerializers\SolrFacetPivotQuerySerializer.cs" />
     <Compile Include="Impl\ISolrDIHStatusParser.cs" />
     <Compile Include="Impl\ResponseParsers\ClusterResponseParser.cs" />
+    <Compile Include="Impl\ResponseParsers\TermsResponseParser.cs" />
     <Compile Include="PivotFacetingResult.cs" />
     <Compile Include="Impl\ResponseParsers\GroupingResponseParser.cs" />
     <Compile Include="SolrFacetPivotQuery.cs" />

--- a/SolrNet/Startup.cs
+++ b/SolrNet/Startup.cs
@@ -114,6 +114,7 @@ namespace SolrNet {
             Container.Register<ISolrResponseParser<T>>(typeof(HighlightingResponseParser<T>).FullName, c => new HighlightingResponseParser<T>());
             Container.Register<ISolrResponseParser<T>>(typeof(MoreLikeThisResponseParser<T>).FullName, c => new MoreLikeThisResponseParser<T>(c.GetInstance<ISolrDocumentResponseParser<T>>()));
             Container.Register<ISolrResponseParser<T>>(typeof(SpellCheckResponseParser<T>).FullName, c => new SpellCheckResponseParser<T>());
+            Container.Register<ISolrResponseParser<T>>(typeof(TermsResponseParser<T>).FullName, c => new TermsResponseParser<T>());
             Container.Register<ISolrResponseParser<T>>(typeof(StatsResponseParser<T>).FullName, c => new StatsResponseParser<T>());
             Container.Register<ISolrResponseParser<T>>(typeof(CollapseResponseParser<T>).FullName, c => new CollapseResponseParser<T>());
             Container.Register<ISolrResponseParser<T>>(typeof(ClusterResponseParser<T>).FullName, c => new ClusterResponseParser<T>());

--- a/StructureMap.SolrNetIntegration.Tests/RegistryTests.cs
+++ b/StructureMap.SolrNetIntegration.Tests/RegistryTests.cs
@@ -99,7 +99,7 @@ namespace StructureMap.SolrNetIntegration.Tests
 
             var field = parser.GetType().GetField("parsers", BindingFlags.NonPublic | BindingFlags.Instance);
             var parsers = (ISolrResponseParser<Entity>[])field.GetValue(parser);
-            Assert.AreEqual(10, parsers.Length);
+            Assert.AreEqual(11, parsers.Length);
             foreach (var t in parsers)
                 Console.WriteLine(t);
         }

--- a/StructureMap.SolrNetIntegration/SolrNetRegistry.cs
+++ b/StructureMap.SolrNetIntegration/SolrNetRegistry.cs
@@ -78,7 +78,8 @@ namespace StructureMap.SolrNetIntegration
                                     typeof(StatsResponseParser<>),
                                     typeof(CollapseResponseParser<>),
                                     typeof(GroupingResponseParser<>),
-                                    typeof(ClusterResponseParser<>)
+                                    typeof(ClusterResponseParser<>),
+                                    typeof(TermsResponseParser<>)
                                 };
 
             foreach (var p in parsers)

--- a/Unity.SolrNetIntegration.Tests/RegistryTests.cs
+++ b/Unity.SolrNetIntegration.Tests/RegistryTests.cs
@@ -98,7 +98,7 @@ namespace Unity.SolrNetIntegration.Tests {
 
       var field = parser.GetType().GetField("parsers", BindingFlags.NonPublic | BindingFlags.Instance);
       var parsers = (ISolrResponseParser<Entity>[]) field.GetValue(parser);
-      Assert.AreEqual(10, parsers.Length);
+      Assert.AreEqual(11, parsers.Length);
       foreach (var t in parsers)
         Console.WriteLine(t);
     }

--- a/Unity.SolrNetIntegration/SolrNetContainerConfiguration.cs
+++ b/Unity.SolrNetIntegration/SolrNetContainerConfiguration.cs
@@ -71,7 +71,8 @@ namespace Unity.SolrNetIntegration {
         typeof (StatsResponseParser<>),
         typeof (CollapseResponseParser<>),
         typeof(GroupingResponseParser<>),
-        typeof(ClusterResponseParser<>)
+        typeof(ClusterResponseParser<>),
+        typeof(TermsResponseParser<>)
       };
 
       foreach (var parser in parsers) {


### PR DESCRIPTION
I needed to implement autocomplete on a site I'm working on so I decided to add it to the client. 

It assumes you've added the TermsComponent to the /select requestHandler. 

Let me know if there are any issues. 

Those two Revert commits I was messing with the github client and didn't realize they were pushing commits I don't think they did anything...
