### PR TITLE
No need to do the decompression yourself, HttpWebRequest knows how to handle this

### DIFF
--- a/SolrNet/Impl/SolrConnection.cs
+++ b/SolrNet/Impl/SolrConnection.cs
@@ -96,6 +96,7 @@ namespace SolrNet.Impl {
             var request = HttpWebRequestFactory.Create(u.Uri);
             request.Method = HttpWebRequestMethod.POST;
             request.KeepAlive = true;
+            request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
             if (Timeout > 0) {
                 request.ReadWriteTimeout = Timeout;
@@ -142,9 +143,7 @@ namespace SolrNet.Impl {
             var request = HttpWebRequestFactory.Create(u.Uri);
             request.Method = HttpWebRequestMethod.GET;
             request.KeepAlive = true;
-
-            //Issue request headers to say we can accept a compressed response
-            request.Headers.Add(HttpRequestHeader.AcceptEncoding, "gzip,deflate");
+            request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
             var cached = Cache[u.Uri.ToString()];
             if (cached != null) {
@@ -205,33 +204,22 @@ namespace SolrNet.Impl {
                 if (cacheControl != null && cacheControl.Contains("no-cache"))
                     etag = null; // avoid caching things marked as no-cache
 
-                return new SolrResponse(etag, UncompressResponse(response));
+                return new SolrResponse(etag, ReadResponseToString(response));
             }
         }
 
         /// <summary>
-        /// Attempts to deflate response stream if compressed in any way.
+        /// Reads the full stream from the response and returns the content as stream,
+        /// using the correct encoding.
         /// </summary>
-        /// <see cref="http://west-wind.com/weblog/posts/102969.aspx"/>
         /// <param name="response">Web response from request to Solr</param>
         /// <returns></returns>
-        private string UncompressResponse(IHttpWebResponse response) {
+        private string ReadResponseToString(IHttpWebResponse response)
+        {
             using (var responseStream = response.GetResponseStream())
-            using (var compressedStream = GetWrappedCompressionStream(response, responseStream)) {
-				using (var reader = new StreamReader(compressedStream, TryGetEncoding(response))) {
+				using (var reader = new StreamReader(responseStream, TryGetEncoding(response))) {
 					return reader.ReadToEnd();
-				}
             }
-        }
-
-        private Stream GetWrappedCompressionStream(IHttpWebResponse response, Stream responseStream) {
-            if (response.ContentEncoding == null)
-                return responseStream;
-            if (response.ContentEncoding.ToLower().Contains("gzip"))
-                return new GZipStream(responseStream, CompressionMode.Decompress);
-            if (response.ContentEncoding.ToLower().Contains("deflate"))
-                return new DeflateStream(responseStream, CompressionMode.Decompress);
-            return responseStream;
         }
 
         private struct SolrResponse {


### PR DESCRIPTION
I have removed the manual decompression from the SolrConnection code. I have no MBUnit setup, so I couldn't run the tests. I'm actually quite sure that the SolrConnectionTests will fail now. I'd suggest removing them completely as they are testing functionality that is now completely pushed down to the framework.
