### PR TITLE
Add Autofac registration of TermsComponent & new unit test for ResponseParsers

### DIFF
--- a/AutofacContrib.SolrNet.Tests/AutofacTests.cs
+++ b/AutofacContrib.SolrNet.Tests/AutofacTests.cs
@@ -15,10 +15,12 @@
 #endregion
 
 using System;
+using System.Reflection;
 using Autofac;
 using MbUnit.Framework;
 using Rhino.Mocks;
 using SolrNet;
+using SolrNet.Impl;
 
 namespace AutofacContrib.SolrNet.Tests {
     [TestFixture]
@@ -65,6 +67,22 @@ namespace AutofacContrib.SolrNet.Tests {
             var basic = container.Resolve<ISolrBasicOperations<Entity>>();
             var basicReadonly = container.Resolve<ISolrBasicReadOnlyOperations<Entity>>();
             Assert.AreSame(basic, basicReadonly);
+        }
+        
+        [Test]
+        public void ResponseParsers()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterModule(new SolrNetModule("http://localhost:8983/solr"));
+            var container = builder.Build();
+
+            var parser = container.Resolve<ISolrQueryResultParser<Entity>>();
+
+            var field = parser.GetType().GetField("parsers", BindingFlags.NonPublic | BindingFlags.Instance);
+            var parsers = (ISolrResponseParser<Entity>[])field.GetValue(parser);
+            Assert.AreEqual(11, parsers.Length);
+            foreach (var t in parsers)
+                Console.WriteLine(t);
         }
 
         public class Entity {}

--- a/AutofacContrib.SolrNet/SolrNetModule.cs
+++ b/AutofacContrib.SolrNet/SolrNetModule.cs
@@ -79,7 +79,8 @@ namespace AutofacContrib.SolrNet {
                 typeof (StatsResponseParser<>),
                 typeof (CollapseResponseParser<>),
                 typeof (GroupingResponseParser<>),
-                typeof (ClusterResponseParser<>)
+                typeof (ClusterResponseParser<>),
+                typeof (TermsResponseParser<>)
             })
                 builder.RegisterGeneric(p).As(typeof (ISolrResponseParser<>));
 
@@ -142,7 +143,8 @@ namespace AutofacContrib.SolrNet {
                 typeof (StatsResponseParser<>),
                 typeof (CollapseResponseParser<>),
                 typeof (GroupingResponseParser<>),
-                typeof (ClusterResponseParser<>)
+                typeof (ClusterResponseParser<>),
+                typeof (TermsResponseParser<>)
             })
 
                 builder.RegisterGeneric(p).As(typeof (ISolrResponseParser<>));


### PR DESCRIPTION
added new TermsComponent registration. 
Also copied ResponseParsers test from StructureMap tests to ensure there is a test for autofac response parsers registration.
