### PR TITLE
Fixed HighlightingResponseParser try #2

### DIFF
--- a/SolrNet.Tests/Resources/responseWithBlankHighlighting.xml
+++ b/SolrNet.Tests/Resources/responseWithBlankHighlighting.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <lst name="responseHeader">
+    <int name="status">0</int>
+    <int name="QTime">16</int>
+    <lst name="params">
+      <str name="hl">true</str>
+    </lst>
+  </lst>
+  <result name="response" numFound="1" start="0">
+    <doc>
+      <str name="guid">SP2514N</str>
+      <str name="id">SP2514N</str>
+    </doc>
+  </result>
+	<lst name="highlighting">
+		<lst/>
+	</lst>
+</response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -264,6 +264,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\responseWithMLTHandlerMatch.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithBlankHighlighting.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -460,6 +460,13 @@ namespace SolrNet.Tests {
             first.Value.Snippets["source_en"].ForEach(Console.WriteLine);
             Assert.AreEqual(3, first.Value.Snippets["source_en"].Count);
         }
+
+		[Test]
+		public void ParseBlankHighlighting()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithBlankHighlighting.xml"));
+			Assert.AreEqual(0, highlights.Count);
+		}
         
         [Test]
         public void ParseSpellChecking() {

--- a/SolrNet/Impl/ResponseParsers/HighlightingResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/HighlightingResponseParser.cs
@@ -46,10 +46,12 @@ namespace SolrNet.Impl.ResponseParsers {
             var highlights = new Dictionary<string, HighlightedSnippets>();
             var docRefs = node.Elements("lst");
             foreach (var docRef in docRefs) {
-                var docRefKey = docRef.Attribute("name").Value;
-                highlights.Add(docRefKey, ParseHighlightingFields(docRef.Elements()));                    
+            	var docRefAttribute = docRef.Attribute("name");
+            	if (docRefAttribute != null) {
+            		highlights.Add(docRefAttribute.Value, ParseHighlightingFields(docRef.Elements()));
+            	}
             }
-            return highlights;
+        	return highlights;
         }
 
         /// <summary>


### PR DESCRIPTION
If solr is configured without a stored uniqueKey, highlighting results will not have a "name" attribute. I changed it to return empty instead of throwing in this case.

(fixed now with a better commit comment and author)
