### PR TITLE
Multiple core/instance support for Ninject

### DIFF
--- a/Ninject.Integration.SolrNet.Tests/App.config
+++ b/Ninject.Integration.SolrNet.Tests/App.config
@@ -1,15 +1,22 @@
 <?xml version="1.0"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Castle.DynamicProxy2" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.3.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
-        <bindingRedirect oldVersion="1.0.3.0" newVersion="1.2.0.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+	<configSections>
+		<section name="solr" type=" Ninject.Integration.SolrNet.Config.SolrConfigurationSection,  Ninject.Integration.SolrNet"/>
+	</configSections>
+	<solr>
+		<server id="entity" url="http://localhost:8983/solr/core0" documentType="Ninject.Integration.SolrNet.Tests.Entity,  Ninject.Integration.SolrNet.Tests"/>
+		<server id="entity2" url="http://localhost:8983/solr/core1" documentType="Ninject.Integration.SolrNet.Tests.Entity2,  Ninject.Integration.SolrNet.Tests"/>
+	</solr>
+		<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Castle.DynamicProxy2" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
+				<bindingRedirect oldVersion="2.0.3.0" newVersion="2.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
+				<bindingRedirect oldVersion="1.0.3.0" newVersion="1.2.0.0"/>
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/Ninject.Integration.SolrNet.Tests/Entity.cs
+++ b/Ninject.Integration.SolrNet.Tests/Entity.cs
@@ -1,0 +1,6 @@
+﻿// 
+namespace Ninject.Integration.SolrNet.Tests {
+    public class Entity {
+         
+    }
+}

--- a/Ninject.Integration.SolrNet.Tests/Entity2.cs
+++ b/Ninject.Integration.SolrNet.Tests/Entity2.cs
@@ -1,0 +1,6 @@
+﻿// 
+namespace Ninject.Integration.SolrNet.Tests {
+    public class Entity2 {
+         
+    }
+}

--- a/Ninject.Integration.SolrNet.Tests/MultiCoreTests.cs
+++ b/Ninject.Integration.SolrNet.Tests/MultiCoreTests.cs
@@ -1,0 +1,151 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using MbUnit.Framework;
+using Ninject.Integration.SolrNet.Config;
+using SolrNet;
+using System.Configuration;
+
+namespace Ninject.Integration.SolrNet.Tests {
+    [TestFixture]
+    public class MultiCoreTests {
+        private StandardKernel kernel;
+        [SetUp]
+        public void SetUp()
+        {
+            kernel = new StandardKernel();
+        }
+
+        [Test]
+        [Category("Integration")]
+        public void ResolveSolrOperations() {
+            //var kernel = new StandardKernel();
+
+            var solrServers = new SolrServers {
+                new SolrServerElement {
+                    Id = "default",
+                    Url = "http://localhost:8983/solr",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                }
+            };
+            kernel.Load(new SolrNetModule(solrServers));
+            var solr = kernel.Get<ISolrOperations<Entity>>();
+            Assert.IsNotNull(solr);
+        }
+
+        [Test, Category("Integration")]
+        public void Ping_And_Query_SingleCore()
+        {
+            var solrServers = new SolrServers {
+                new SolrServerElement {
+                    Id = "default",
+                    Url = "http://localhost:8983/solr/core0",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                }
+            };
+            kernel.Load(new SolrNetModule(solrServers));
+            var solr = kernel.Get<ISolrOperations<Entity>>();
+            solr.Ping();
+            Console.WriteLine(solr.Query(SolrQuery.All).Count);
+        }
+
+        [Test, Category("Integration")]
+        public void Resolve_MultiCore_FromConfig()
+        {
+            var solrConfig = (SolrConfigurationSection)ConfigurationManager.GetSection("solr");
+            kernel.Load(new SolrNetModule(solrConfig.SolrServers));
+
+            var solrOperations = kernel.Get<ISolrOperations<Entity>>();
+            Assert.IsNotNull(solrOperations);
+
+            var solrOperations2 = kernel.Get<ISolrOperations<Entity2>>();
+            Assert.IsNotNull(solrOperations2);
+        }
+
+        [Test, Category("Integration")]
+        public void Ping_And_Query_MultiCore()
+        {
+            var solrServers = new SolrServers {
+                new SolrServerElement {
+                    Id = "main",
+                    Url = "http://localhost:8983/solr/core0",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                },
+                new SolrServerElement {
+                    Id = "alt",
+                    Url = "http://localhost:8983/solr/core1",
+                    DocumentType = typeof(Entity2).AssemblyQualifiedName,
+                }
+            };
+            kernel.Load(new SolrNetModule(solrServers));
+            var solr1 = kernel.Get<ISolrOperations<Entity>>();
+            solr1.Ping();
+            Console.WriteLine("Query core 1: {0}",solr1.Query(SolrQuery.All).Count);
+            var solr2 = kernel.Get<ISolrOperations<Entity2>>();
+            solr2.Ping();
+            Console.WriteLine("Query core 2: {0}", solr2.Query(SolrQuery.All).Count);
+        }
+
+        [Test, Category("Integration")]
+        public void MultiCore_GetByName()
+        {
+            var solrServers = new SolrServers {
+                new SolrServerElement {
+                    Id = "core-0",
+                    Url = "http://localhost:8983/solr/core0",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                },
+                new SolrServerElement {
+                    Id = "core-1",
+                    Url = "http://localhost:8983/solr/core1",
+                    DocumentType = typeof(Entity2).AssemblyQualifiedName,
+                }
+            };
+            kernel.Load(new SolrNetModule(solrServers));
+            var solr1 = kernel.Get<ISolrOperations<Entity>>("core-0");
+            Assert.IsNotNull(solr1);
+            Console.WriteLine("Query core 1: {0}", solr1.Query(SolrQuery.All).Count);
+            var solr2 = kernel.Get<ISolrOperations<Entity2>>("core-1");
+            Assert.IsNotNull(solr2);
+            solr2.Ping();
+            Console.WriteLine("Query core 2: {0}", solr2.Query(SolrQuery.All).Count);
+        }
+
+        [Test, Category("Integration")]
+        [Ignore]
+        public void MultiCore_SameClassBinding()
+        {
+            var solrServers = new SolrServers {
+                new SolrServerElement {
+                    Id = "core-0",
+                    Url = "http://localhost:8983/solr/core0",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                },
+                new SolrServerElement {
+                    Id = "core-1",
+                    Url = "http://localhost:8983/solr/core1",
+                    DocumentType = typeof(Entity).AssemblyQualifiedName,
+                }
+            };
+            kernel.Load(new SolrNetModule(solrServers));
+            var solr1 = kernel.Get<ISolrOperations<Entity>>("core-0");
+            Assert.IsNotNull(solr1);
+            var solr2 = kernel.Get<ISolrOperations<Entity>>("core-1");
+            Assert.IsNotNull(solr2);
+        }
+    }
+}

--- a/Ninject.Integration.SolrNet.Tests/Ninject.Integration.SolrNet.Tests.csproj
+++ b/Ninject.Integration.SolrNet.Tests/Ninject.Integration.SolrNet.Tests.csproj
@@ -66,6 +66,7 @@
       <HintPath>..\lib\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -79,6 +80,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Entity.cs" />
+    <Compile Include="Entity2.cs" />
+    <Compile Include="MultiCoreTests.cs" />
     <Compile Include="Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Ninject.Integration.SolrNet/Config/SolrConfigurationSection.cs
+++ b/Ninject.Integration.SolrNet/Config/SolrConfigurationSection.cs
@@ -1,0 +1,34 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Configuration;
+
+namespace Ninject.Integration.SolrNet.Config {
+    /// <summary>
+    /// Configuration section for Solr servers
+    /// </summary>
+    public class SolrConfigurationSection : ConfigurationSection
+    {
+        /// <summary>
+        /// Solr Servers configuration settings
+        /// </summary>
+        [ConfigurationProperty("", IsDefaultCollection = true)]
+        public SolrServers SolrServers
+        {
+            get { return (SolrServers)base[""]; }
+        }
+    }         
+}

--- a/Ninject.Integration.SolrNet/Config/SolrServerElement.cs
+++ b/Ninject.Integration.SolrNet/Config/SolrServerElement.cs
@@ -1,0 +1,38 @@
+﻿// 
+
+using System.Configuration;
+
+namespace Ninject.Integration.SolrNet.Config {
+    public class SolrServerElement : ConfigurationElement
+    {
+        private const string ID = "id";
+        private const string URL = "url";
+        private const string DOCUMENT_TYPE = "documentType";
+
+        [ConfigurationProperty(ID, IsKey = true, IsRequired = true)]
+        public string Id
+        {
+            get { return base[ID].ToString(); }
+            set { base[ID] = value; }
+        }
+
+        [ConfigurationProperty(URL, IsKey = true, IsRequired = true)]
+        public string Url
+        {
+            get { return base[URL].ToString(); }
+            set { base[URL] = value; }
+        }
+
+        [ConfigurationProperty(DOCUMENT_TYPE, IsKey = true, IsRequired = true)]
+        public string DocumentType
+        {
+            get { return base[DOCUMENT_TYPE].ToString(); }
+            set { base[DOCUMENT_TYPE] = value; }
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Id: {0} Url: {1} DocType: {2}", Id, Url, DocumentType);
+        }
+    }
+}

--- a/Ninject.Integration.SolrNet/Config/SolrServers.cs
+++ b/Ninject.Integration.SolrNet/Config/SolrServers.cs
@@ -1,0 +1,32 @@
+﻿// 
+using System.Configuration;
+
+namespace Ninject.Integration.SolrNet.Config {
+    public class SolrServers : ConfigurationElementCollection {
+        public void Add(SolrServerElement configurationElement)
+        {
+            base.BaseAdd(configurationElement);
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new SolrServerElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            var solrServerElement = (SolrServerElement)element;
+            return solrServerElement.Url + solrServerElement.DocumentType;
+        }
+
+        public override ConfigurationElementCollectionType CollectionType
+        {
+            get { return ConfigurationElementCollectionType.BasicMap; }
+        }
+
+        protected override string ElementName
+        {
+            get { return "server"; }
+        }         
+    }
+}

--- a/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.csproj
+++ b/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.csproj
@@ -60,10 +60,16 @@
       <HintPath>..\lib\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\SolrConfigurationSection.cs" />
+    <Compile Include="Config\SolrServerElement.cs" />
+    <Compile Include="Config\SolrServers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SolrCore.cs" />
     <Compile Include="SolrNetModule.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Ninject.Integration.SolrNet/SolrCore.cs
+++ b/Ninject.Integration.SolrNet/SolrCore.cs
@@ -1,0 +1,31 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+namespace Ninject.Integration.SolrNet {
+    internal class SolrCore {
+        public string Id { get; private set; }
+        public string Url { get; private set; }
+        public Type DocumentType { get; private set; }
+
+        public SolrCore(string id, Type documentType, string url) {
+            Id = id;
+            DocumentType = documentType;
+            Url = url;
+        }
+    }
+}


### PR DESCRIPTION
Mauricio,

I just added multiple core/instance support for the Ninject Integration project. I was not able to figure out how to access multiple cores/instances with the same mapped types. However, it works just fine for different mapped types.

Please review and let me know if there are any needed changes.

Thanks,
Paige
