### PR TITLE
SolrQueryByField issue

### DIFF
--- a/SolrNet.Tests/LocalParamsTests.cs
+++ b/SolrNet.Tests/LocalParamsTests.cs
@@ -82,7 +82,7 @@ namespace SolrNet.Tests {
             };
             var q = new SolrQueryByField("field", "value");
             var qq = p + q;
-            Assert.AreEqual("{!type=spatial}(field:value)", SerializeQuery(qq));
+            Assert.AreEqual("{!type=spatial}field:(value)", SerializeQuery(qq));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace SolrNet.Tests {
             var q = new SolrQueryByField("field", "value");
             var q2 = new SolrQueryByRange<decimal>("price", 100m, 200m);
             var qq = p + (q + q2);
-            Assert.AreEqual("{!type=spatial}((field:value)  price:[100 TO 200])", SerializeQuery(qq));
+            Assert.AreEqual("{!type=spatial}(field:(value)  price:[100 TO 200])", SerializeQuery(qq));
         }
     }
 }

--- a/SolrNet.Tests/OperatorOverloadingTests.cs
+++ b/SolrNet.Tests/OperatorOverloadingTests.cs
@@ -43,25 +43,25 @@ namespace SolrNet.Tests {
         [Test]
         public void MultipleAnd() {
             var q = new SolrQuery("solr") && new SolrQuery("name:desc") && new SolrQueryByField("id", "123456");
-            Assert.AreEqual("((solr AND name:desc) AND (id:123456))", Serialize(q));
+            Assert.AreEqual("((solr AND name:desc) AND id:(123456))", Serialize(q));
         }
 
         [Test]
         public void MultipleOr() {
             var q = new SolrQuery("solr") || new SolrQuery("name:desc") || new SolrQueryByField("id", "123456");
-            Assert.AreEqual("((solr OR name:desc) OR (id:123456))", Serialize(q));
+            Assert.AreEqual("((solr OR name:desc) OR id:(123456))", Serialize(q));
         }
 
         [Test]
         public void MixedAndOrs_obeys_operator_precedence() {
             var q = new SolrQuery("solr") || new SolrQuery("name:desc") && new SolrQueryByField("id", "123456");
-            Assert.AreEqual("(solr OR (name:desc AND (id:123456)))", Serialize(q));
+            Assert.AreEqual("(solr OR (name:desc AND id:(123456)))", Serialize(q));
         }
 
         [Test]
         public void MixedAndOrs_with_parentheses_obeys_precedence() {
             var q = (new SolrQuery("solr") || new SolrQuery("name:desc")) && new SolrQueryByField("id", "123456");
-            Assert.AreEqual("((solr OR name:desc) AND (id:123456))", Serialize(q));
+            Assert.AreEqual("((solr OR name:desc) AND id:(123456))", Serialize(q));
         }
 
         [Test]

--- a/SolrNet.Tests/SolrMultipleCriteriaQueryTests.cs
+++ b/SolrNet.Tests/SolrMultipleCriteriaQueryTests.cs
@@ -45,7 +45,7 @@ namespace SolrNet.Tests {
             var q2 = new SolrQueryByField("f", "v");
             var qm = new SolrMultipleCriteriaQuery(new ISolrQuery[] {q1, q2});
             Console.WriteLine(Serialize(qm));
-            Assert.AreEqual("(1  (f:v))", Serialize(qm));
+            Assert.AreEqual("(1  f:(v))", Serialize(qm));
         }
 
 
@@ -79,7 +79,7 @@ namespace SolrNet.Tests {
         public void StaticConstructor() {
             var q = SolrMultipleCriteriaQuery.Create(new SolrQueryByField("id", "123"), new SolrQuery("solr"));
             Assert.AreEqual(2, q.Queries.Count());
-            Assert.AreEqual("((id:123)  solr)", Serialize(q));
+            Assert.AreEqual("(id:(123)  solr)", Serialize(q));
             Assert.IsEmpty(q.Oper);
         }
     }

--- a/SolrNet.Tests/SolrNotQueryTests.cs
+++ b/SolrNet.Tests/SolrNotQueryTests.cs
@@ -39,7 +39,7 @@ namespace SolrNet.Tests {
         public void QueryByField() {
             var q = new SolrQueryByField("desc", "samsung");
             var notq = new SolrNotQuery(q);
-            Assert.AreEqual("-(desc:samsung)", Serialize(notq));
+            Assert.AreEqual("-desc:(samsung)", Serialize(notq));
         }
 
         [Test]
@@ -53,20 +53,20 @@ namespace SolrNet.Tests {
         public void QueryInList() {
             var q = new SolrQueryInList("desc", "samsung", "hitachi", "fujitsu");
             var notq = new SolrNotQuery(q);
-            Assert.AreEqual("-((desc:samsung) OR (desc:hitachi) OR (desc:fujitsu))", Serialize(notq));
+            Assert.AreEqual("-(desc:(samsung) OR desc:(hitachi) OR desc:(fujitsu))", Serialize(notq));
         }
 
         [Test]
         public void MultipleCriteria() {
             var q = SolrMultipleCriteriaQuery.Create(new SolrQueryByField("desc", "samsung"), new SolrQueryByRange<decimal>("price", 100, 200));
             var notq = new SolrNotQuery(q);
-            Assert.AreEqual("-((desc:samsung)  price:[100 TO 200])", Serialize(notq));
+            Assert.AreEqual("-(desc:(samsung)  price:[100 TO 200])", Serialize(notq));
         }
 
         [Test]
         public void MultipleCriteria_not() {
             var q = SolrMultipleCriteriaQuery.Create(new SolrQueryByField("desc", "samsung"), new SolrQueryByRange<decimal>("price", 100, 200));
-            Assert.AreEqual("-((desc:samsung)  price:[100 TO 200])", Serialize(q.Not()));
+            Assert.AreEqual("-(desc:(samsung)  price:[100 TO 200])", Serialize(q.Not()));
         }
 
         [Test]

--- a/SolrNet.Tests/SolrQueryByFieldTests.cs
+++ b/SolrNet.Tests/SolrQueryByFieldTests.cs
@@ -45,31 +45,31 @@ namespace SolrNet.Tests {
         [Test]
         public void EmptyValue() {
             var q = new SolrQueryByField("id", "");
-            Assert.AreEqual("(id:\"\")", Serialize(q));
+            Assert.AreEqual("id:(\"\")", Serialize(q));
         }
 
 		[Test]
 		public void Basic() {
 			var q = new SolrQueryByField("id", "123456");
-			Assert.AreEqual("(id:123456)", Serialize(q));
+            Assert.AreEqual("id:(123456)", Serialize(q));
 		}
 
 		[Test]
 		public void ShouldQuoteSpaces() {
 			var q = new SolrQueryByField("id", "hello world");
-			Assert.AreEqual("(id:\"hello world\")", Serialize(q));
+            Assert.AreEqual("id:(\"hello world\")", Serialize(q));
 		}
 
 		[Test]
 		public void ShouldQuoteSpecialChar() {
 			var q = new SolrQueryByField("id", "hello+world-bye&&q||w!e(r)t{y}[u]^i\"o~p:a\\s+d;;?*");
-			Assert.AreEqual(@"(id:hello\+world\-bye\&&q\||w\!e\(r\)t\{y\}\[u\]\^i\""o\~p\:a\\s\+d\;\;\?\*)", Serialize(q));
+            Assert.AreEqual(@"id:(hello\+world\-bye\&&q\||w\!e\(r\)t\{y\}\[u\]\^i\""o\~p\:a\\s\+d\;\;\?\*)", Serialize(q));
 		}
 
         [Test]
         public void QuotedFalse() {
             var q = new SolrQueryByField("id", "hello?world*") { Quoted = false };
-            Assert.AreEqual("(id:hello?world*)", Serialize(q));
+            Assert.AreEqual("id:(hello?world*)", Serialize(q));
         }
 	}
 }

--- a/SolrNet.Tests/SolrQueryExecuterTests.cs
+++ b/SolrNet.Tests/SolrQueryExecuterTests.cs
@@ -444,7 +444,7 @@ namespace SolrNet.Tests {
                         Rows = 5,
                         Fields = new[] { "one", "two", "three" },
                     }).ToList();
-            Assert.Contains(p, KV.Create("q", "(id:1234)"));
+            Assert.Contains(p, KV.Create("q", "id:(1234)"));
             Assert.Contains(p, KV.Create("start", "0"));
             Assert.Contains(p, KV.Create("rows", "5"));
             Assert.Contains(p, KV.Create("fl", "one,two,three"));

--- a/SolrNet.Tests/SolrQueryInListTests.cs
+++ b/SolrNet.Tests/SolrQueryInListTests.cs
@@ -31,20 +31,20 @@ namespace SolrNet.Tests {
 		[Test]
 		public void ListOfInt() {
 			var q = new SolrQueryInList("id", new[] {1, 2, 3, 4}.Select(i => i.ToString()));
-			Assert.AreEqual("((id:1) OR (id:2) OR (id:3) OR (id:4))", Serialize(q));
+            Assert.AreEqual("(id:(1) OR id:(2) OR id:(3) OR id:(4))", Serialize(q));
 		}
 
         [Test]
         public void ShouldQuoteValues() {
             var q = new SolrQueryInList("id", new[] {"one", "two thousand"});
-            Assert.AreEqual("((id:one) OR (id:\"two thousand\"))", Serialize(q));
+            Assert.AreEqual("(id:(one) OR id:(\"two thousand\"))", Serialize(q));
         }
 
 
         [Test]
         public void ShouldQuoteEmptyValues() {
             var q = new SolrQueryInList("id", new[] { "", "two thousand" });
-            Assert.AreEqual("((id:\"\") OR (id:\"two thousand\"))", Serialize(q));
+            Assert.AreEqual("(id:(\"\") OR id:(\"two thousand\"))", Serialize(q));
         }
 
         [Test]

--- a/SolrNet/Impl/QuerySerializers/QueryByFieldSerializer.cs
+++ b/SolrNet/Impl/QuerySerializers/QueryByFieldSerializer.cs
@@ -22,7 +22,7 @@ namespace SolrNet.Impl.QuerySerializers {
         public override string Serialize(SolrQueryByField q) {
             if (q.FieldName == null || q.FieldValue == null)
                 return null;
-            return string.Format("({0}:{1})", q.FieldName, q.Quoted ? Quote(q.FieldValue) : q.FieldValue);
+            return string.Format("{0}:({1})", q.FieldName, q.Quoted ? Quote(q.FieldValue) : q.FieldValue);
         }
 
         public static readonly Regex SpecialCharactersRx = new Regex("(\\+|\\-|\\&\\&|\\|\\||\\!|\\{|\\}|\\[|\\]|\\^|\\(|\\)|\\\"|\\~|\\:|\\;|\\\\|\\?|\\*)", RegexOptions.Compiled);


### PR DESCRIPTION
Before if I added a query new SolrQueryByField("field","value to search"){Quoted = false} then it would create the following expression (field:value to search) which would parse in solr as field:value defaultSearchField:to defaultSearchField:search
This update means that it will create the expression field:(value to search) which will parse as field:value field:to field:search

Before if I added a query new SolrQueryByField("field",")value to search"){Quoted = false} it would not escape the )
The update escapes any special characters even if Quoted is turned off.
