### PR TITLE
Allow rebinding ISolrConnection when using multiple cores.

### DIFF
--- a/Ninject.Integration.SolrNet/SolrNetModule.cs
+++ b/Ninject.Integration.SolrNet/SolrNetModule.cs
@@ -128,15 +128,15 @@ namespace Ninject.Integration.SolrNet {
 
             Bind<ISolrConnection>().ToConstant(new SolrConnection(core.Url)).Named(coreConnectionId);
             Bind(solrOperations).To(solrServer).Named(core.Id)
-                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(coreConnectionId));
+                .WithConstructorArgument("connection", ctx => ctx.Kernel.Get<ISolrConnection>(coreConnectionId));
             Bind(solrReadOnlyOperations).To(solrServer).Named(core.Id)
-                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(coreConnectionId));
+                .WithConstructorArgument("connection", ctx => ctx.Kernel.Get<ISolrConnection>(coreConnectionId));
             Bind(solrBasicOperations).To(solrBasicServer).Named(core.Id)
-                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(coreConnectionId));
+                .WithConstructorArgument("connection", ctx => ctx.Kernel.Get<ISolrConnection>(coreConnectionId));
             Bind(solrBasicReadOnlyOperations).To(solrBasicServer).Named(core.Id)
-                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(coreConnectionId));
+                .WithConstructorArgument("connection", ctx => ctx.Kernel.Get<ISolrConnection>(coreConnectionId));
             Bind(iSolrQueryExecuter).To(solrQueryExecuter).Named(core.Id)
-                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(coreConnectionId));
+                .WithConstructorArgument("connection", ctx => ctx.Kernel.Get<ISolrConnection>(coreConnectionId));
         }
 
         


### PR DESCRIPTION
When using multiple cores ISolrConnection was created at binding time, not activation time like in single core. That made impossible to rebind ISolrConnection (for example to use for logging) after adding new core.

This patch makes it possible.
