### PR TITLE
Removed named bindings in the ninject module for multicore

### DIFF
--- a/Ninject.Integration.SolrNet.Tests/MultiCoreTests.cs
+++ b/Ninject.Integration.SolrNet.Tests/MultiCoreTests.cs
@@ -125,7 +125,6 @@ namespace Ninject.Integration.SolrNet.Tests {
         }
 
         [Test]
-        [Ignore("Not implemented yet")]
         public void MultiCore_SameClassBinding()
         {
             var solrServers = new SolrServers {

--- a/Ninject.Integration.SolrNet/SolrNetModule.cs
+++ b/Ninject.Integration.SolrNet/SolrNetModule.cs
@@ -33,6 +33,7 @@ using SolrNet.Mapping.Validation.Rules;
 using SolrNet.Schema;
 using SolrNet.Utils;
 using Ninject.Planning.Bindings;
+using Ninject.Activation;
 
 namespace Ninject.Integration.SolrNet {
     /// <summary>
@@ -41,7 +42,7 @@ namespace Ninject.Integration.SolrNet {
     public class SolrNetModule : NinjectModule {
         private readonly string serverURL;
         private readonly List<SolrCore> cores = new List<SolrCore>();
- 
+        private const string CoreId = "CoreId";
         /// <summary>
         /// Optional override for document mapper
         /// </summary>
@@ -117,21 +118,47 @@ namespace Ninject.Integration.SolrNet {
         }
 
         private void RegisterCore(SolrCore core) {
-            var solrBasicOperations = typeof(ISolrBasicOperations<>).MakeGenericType(core.DocumentType);
-            var solrOperations = typeof(ISolrOperations<>).MakeGenericType(core.DocumentType);
-            var solrReadOnlyOperations = typeof(ISolrReadOnlyOperations<>).MakeGenericType(core.DocumentType);
-            var solrServer = typeof(SolrServer<>).MakeGenericType(core.DocumentType);
-            var solrBasicReadOnlyOperations = typeof(ISolrBasicReadOnlyOperations<>).MakeGenericType(core.DocumentType);
-            var solrBasicServer = typeof(SolrBasicServer<>).MakeGenericType(core.DocumentType);
+            string coreConnectionId = core.Id;
+
+            Bind<ISolrConnection>().ToConstant(new SolrConnection(core.Url))
+                .WithMetadata(CoreId, coreConnectionId);
+
             var iSolrQueryExecuter = typeof(ISolrQueryExecuter<>).MakeGenericType(core.DocumentType);
             var solrQueryExecuter = typeof(SolrQueryExecuter<>).MakeGenericType(core.DocumentType);
 
-            Bind<ISolrConnection>().ToConstant(new SolrConnection(core.Url)).When(x => x.ParentRequest != null && x.ParentRequest.Service != null && x.ParentRequest.Service.IsGenericType && x.ParentRequest.Service.GetGenericArguments()[0].Equals(core.DocumentType));
-            Bind(solrOperations).To(solrServer);
-            Bind(solrReadOnlyOperations).To(solrServer);
-            Bind(solrBasicOperations).To(solrBasicServer);
-            Bind(solrBasicReadOnlyOperations).To(solrBasicServer);
-            Bind(iSolrQueryExecuter).To(solrQueryExecuter);
+            Bind(iSolrQueryExecuter).To(solrQueryExecuter)
+                .Named(coreConnectionId + solrQueryExecuter)
+                .WithMetadata(CoreId, coreConnectionId)
+                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)));
+
+            var solrBasicOperations = typeof(ISolrBasicOperations<>).MakeGenericType(core.DocumentType);
+            var solrBasicReadOnlyOperations = typeof(ISolrBasicReadOnlyOperations<>).MakeGenericType(core.DocumentType);
+            var solrBasicServer = typeof(SolrBasicServer<>).MakeGenericType(core.DocumentType);
+
+            Bind(solrBasicOperations).To(solrBasicServer)
+                .Named(coreConnectionId + solrBasicServer)
+                .WithMetadata(CoreId, coreConnectionId)
+                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)))
+                .WithConstructorArgument("queryExecuter", Kernel.Get(iSolrQueryExecuter, bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)));
+
+            Bind(solrBasicReadOnlyOperations).To(solrBasicServer)
+                .Named(coreConnectionId + solrBasicServer)
+                .WithMetadata(CoreId, coreConnectionId)
+                .WithConstructorArgument("connection", Kernel.Get<ISolrConnection>(bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)))
+                .WithConstructorArgument("queryExecuter", Kernel.Get(iSolrQueryExecuter,bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)));
+
+            var solrOperations = typeof(ISolrOperations<>).MakeGenericType(core.DocumentType);
+            var solrServer = typeof(SolrServer<>).MakeGenericType(core.DocumentType);
+            var solrReadOnlyOperations = typeof(ISolrReadOnlyOperations<>).MakeGenericType(core.DocumentType);
+
+            Bind(solrOperations).To(solrServer)
+                .Named(core.Id)
+                .WithMetadata(CoreId, coreConnectionId)
+                .WithConstructorArgument("basicServer", Kernel.Get(solrBasicOperations, bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)));
+            Bind(solrReadOnlyOperations).To(solrServer)
+                .Named(core.Id)
+                .WithMetadata(CoreId, coreConnectionId)
+                .WithConstructorArgument("basicServer", Kernel.Get(solrBasicReadOnlyOperations, bindingMetaData => bindingMetaData.Has(CoreId) && bindingMetaData.Get<string>(CoreId).Equals(coreConnectionId)));
         }
 
         public override void Load() {


### PR DESCRIPTION
I was using the ninject module in a project and I needed to unbind the ISolrConnection so I could inject a different URL from a settings repository that was resolved later.

For some reason I could not get the named bindings to unbind. 

kernel.Unbind<ISolrConnection> didn't seem to work until I changed the code to resolve the ISolrConnection based on the DocumentType rather than the core names.
