### PR TITLE
Added ms to DateTimeFieldSerializer

### DIFF
--- a/SolrNet/Impl/FieldSerializers/DateTimeFieldSerializer.cs
+++ b/SolrNet/Impl/FieldSerializers/DateTimeFieldSerializer.cs
@@ -23,7 +23,7 @@ namespace SolrNet.Impl.FieldSerializers {
     /// </summary>
     public class DateTimeFieldSerializer : AbstractFieldSerializer<DateTime> {
         public string SerializeDate(DateTime dt) {
-            return dt.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            return dt.ToString("yyyy-MM-dd'T'HH:mm:ss.FFF'Z'");
         }
 
         public override IEnumerable<PropertyNode> Parse(DateTime obj) {


### PR DESCRIPTION
From field doc:
The format for this date field is of the form 1995-12-31T23:59:59Z, and is a more restricted form of the canonical representation of dateTime
http://www.w3.org/TR/xmlschema-2/#dateTime  
The trailing "Z" designates UTC time and is mandatory.
Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
All other components are mandatory.

DateTimeFieldParser already supports ms
