### PR TITLE
Improve null handling for & and | during query composition

### DIFF
--- a/SolrNet.DSL.Tests/QueryBuildingTests.cs
+++ b/SolrNet.DSL.Tests/QueryBuildingTests.cs
@@ -90,5 +90,35 @@ namespace SolrNet.DSL.Tests {
             var q = Query.Field("name").HasAnyValue();
             Assert.AreEqual("name:[* TO *]", Serialize(q));
         }
+
+        [Test]
+        public void CompositionIgnoreNullOR() {
+            var qLeft = Query.Field("left").Is("left");
+            var qRight = Query.Field("right").Is("right");
+            Assert.AreEqual(qLeft || null, qLeft);
+            Assert.AreEqual(null || qRight, qRight);
+            AbstractSolrQuery composite = null;
+            composite |= qRight;
+            Assert.AreEqual(composite, qRight);
+            composite = qLeft || qRight;
+            Assert.AreNotEqual(composite, qLeft);
+            Assert.AreNotEqual(composite, qRight);
+        }
+
+        [Test]
+        public void CompositionIgnoreNullAND()
+        {
+            var qLeft = Query.Field("left").Is("left");
+            var qRight = Query.Field("right").Is("right");
+            Assert.AreEqual(qLeft & null, qLeft);
+            Assert.AreEqual(null & qRight, qRight);
+            AbstractSolrQuery composite = null;
+            composite &= qRight;
+            Assert.AreEqual(composite, qRight);
+            composite = qLeft & qRight;
+            Assert.AreNotEqual(composite, qLeft);
+            Assert.AreNotEqual(composite, qRight);
+        }
+
     }
 }

--- a/SolrNet/AbstractSolrQuery.cs
+++ b/SolrNet/AbstractSolrQuery.cs
@@ -45,11 +45,19 @@ namespace SolrNet {
         }
 
         public static AbstractSolrQuery operator & (AbstractSolrQuery a, AbstractSolrQuery b) {
-            return new SolrMultipleCriteriaQuery(new[] {a, b}, "AND");
+            return (a == null)
+                ? b 
+                : (b == null)
+                    ? a
+                    : new SolrMultipleCriteriaQuery(new[] {a, b}, "AND");
         }
 
         public static AbstractSolrQuery operator | (AbstractSolrQuery a, AbstractSolrQuery b) {
-            return new SolrMultipleCriteriaQuery(new[] { a, b }, "OR");
+            return (a == null)
+                ? b 
+                : (b == null)
+                    ? a
+                    : new SolrMultipleCriteriaQuery(new[] { a, b }, "OR");
         }
 
         public static AbstractSolrQuery operator + (AbstractSolrQuery a, AbstractSolrQuery b) {


### PR DESCRIPTION
Made Query composition & and | deal more gracefully with nulls by just
keeping non-null expression. This allows for easier query buildilng in
the loops by starting with NULL and just adding to it as appropriate.
Simplifies expressions like this:
finalQuery = (finalQuery == null) ? schemaQuery : (finalQuery &&
schemaQuery);

(My first ever pull request - hopefully, I got it right)
