### PR TITLE
Removed unused GetFields call

### DIFF
--- a/SolrNet/Impl/SolrDocumentResponseParser.cs
+++ b/SolrNet/Impl/SolrDocumentResponseParser.cs
@@ -43,7 +43,6 @@ namespace SolrNet.Impl {
             var results = new List<T>();
             if (parentNode == null)
                 return results;
-            var allFields = mappingManager.GetFields(typeof (T));
             var nodes = parentNode.Elements("doc");
             foreach (var docNode in nodes) {
                 results.Add(ParseDocument(docNode));


### PR DESCRIPTION
Hi Mauricio, I noticed this unused GetFields call in SolrDocumentResponseParser.while profiling today.
