### PR TITLE
Support for named registration via Autofac

### DIFF
--- a/AutofacContrib.SolrNet.Tests/AutofacMulticoreTests.cs
+++ b/AutofacContrib.SolrNet.Tests/AutofacMulticoreTests.cs
@@ -20,6 +20,7 @@ using AutofacContrib.SolrNet.Config;
 using MbUnit.Framework;
 using SolrNet;
 using SolrNet.Impl;
+using System.Collections.Generic;
 
 namespace AutofacContrib.SolrNet.Tests
 {
@@ -100,6 +101,96 @@ namespace AutofacContrib.SolrNet.Tests
             // Assert
             Assert.IsTrue(solrOperations1 is SolrServer<Entity1>);
             Assert.IsTrue(solrOperations2 is SolrServer<Entity2>);
+        }
+
+        [Test]
+        public void ResolveSolrOperations_viaNamedWithMultiCore()
+        {
+            // Arrange 
+            var builder = new ContainerBuilder();
+            var cores = new SolrServers {
+                                new SolrServerElement {
+                                        Id = "entity1",
+                                        DocumentType = typeof (Entity1).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreEntity1",
+                                    },
+                               new SolrServerElement {
+                                        Id = "entity2",
+                                        DocumentType = typeof (Entity2).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreEntity2",
+                                },
+                            };
+
+            builder.RegisterModule(new SolrNetModule(cores));
+            var container = builder.Build();
+
+            // Act
+            var solrOperations1 = container.ResolveNamed<ISolrOperations<Entity1>>("entity1");
+            var solrOperations2 = container.ResolveNamed<ISolrOperations<Entity2>>("entity2");
+
+            // Assert
+            Assert.IsTrue(solrOperations1 is SolrServer<Entity1>);
+            Assert.IsTrue(solrOperations2 is SolrServer<Entity2>);
+        }
+
+        [Test]
+        public void ResolveSolrOperations_viaNamedWithMultiCoreForDictionary()
+        {
+            // Arrange 
+            var builder = new ContainerBuilder();
+            var cores = new SolrServers {
+                                new SolrServerElement {
+                                        Id = "dictionary1",
+                                        DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreDictionaryEntity1",
+                                    },
+                               new SolrServerElement {
+                                        Id = "dictionary2",
+                                        DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreDictionaryEntity2",
+                                },
+                            };
+
+            builder.RegisterModule(new SolrNetModule(cores));
+            var container = builder.Build();
+
+            // Act
+            var solrOperations1 = container.ResolveNamed<ISolrOperations<Dictionary<string, object>>>("dictionary1");
+            var solrOperations2 = container.ResolveNamed<ISolrOperations<Dictionary<string, object>>>("dictionary2");
+
+            // Assert
+            Assert.IsTrue(solrOperations1 is SolrServer<Dictionary<string, object>>);
+            Assert.IsTrue(solrOperations2 is SolrServer<Dictionary<string, object>>);
+        }
+
+        [Test]
+        public void ResolveSolrReadOnlyOperations_viaNamedWithMultiCoreForDictionary()
+        {
+            // Arrange 
+            var builder = new ContainerBuilder();
+            var cores = new SolrServers {
+                                new SolrServerElement {
+                                        Id = "dictionary1",
+                                        DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreDictionaryEntity1",
+                                    },
+                               new SolrServerElement {
+                                        Id = "dictionary2",
+                                        DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
+                                        Url = "http://localhost:8983/solr/coreDictionaryEntity2",
+                                },
+                            };
+
+            builder.RegisterModule(new SolrNetModule(cores));
+            var container = builder.Build();
+
+            // Act
+            var solrReadOnlyOperations1 = container.ResolveNamed<ISolrReadOnlyOperations<Dictionary<string, object>>>("dictionary1");
+            var solrReadOnlyOperations2 = container.ResolveNamed<ISolrReadOnlyOperations<Dictionary<string, object>>>("dictionary2");
+
+            // Assert
+            Assert.IsTrue(solrReadOnlyOperations1 is SolrServer<Dictionary<string, object>>);
+            Assert.IsTrue(solrReadOnlyOperations2 is SolrServer<Dictionary<string, object>>);
         }
 
         [Test]

--- a/AutofacContrib.SolrNet/SolrNetModule.cs
+++ b/AutofacContrib.SolrNet/SolrNetModule.cs
@@ -170,12 +170,14 @@ namespace AutofacContrib.SolrNet {
             var SolrServer = typeof (SolrServer<>).MakeGenericType(core.DocumentType);
 
             builder.RegisterType(SolrServer)
+                .Named(core.Id, ISolrOperations)
                 .As(ISolrOperations)
                 .WithParameters(new[] {
                     new ResolvedParameter((p, c) => p.Name == "basicServer", (p, c) => c.ResolveNamed(core.Id + SolrBasicServer, ISolrBasicOperations)),
                 });
 
             builder.RegisterType(SolrServer)
+                .Named(core.Id, ISolrReadOnlyOperations)
                 .As(ISolrReadOnlyOperations)
                 .WithParameters(new[] {
                     new ResolvedParameter((p, c) => p.Name == "basicServer", (p, c) => c.ResolveNamed(core.Id + SolrBasicServer, ISolrBasicOperations)),


### PR DESCRIPTION
Useful when using multiple cores as you can ask the container to resolve by name rather than by document type.

If you have multiple cores each with the same document type, then you have to use named registration.

For example, if you have two cores with the same document type `Dictionary<string, object>`:

``` c#
var builder = new ContainerBuilder();
var cores = new SolrServers {
                    new SolrServerElement {
                            Id = "entity1",
                            DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
                            Url = "http://localhost:8983/solr/coreEntity1",
                        },
                    new SolrServerElement {
                            Id = "entity2",
                            DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
                            Url = "http://localhost:8983/solr/coreEntity2",
                    },
                };

builder.RegisterModule(new SolrNetModule(cores));
var container = builder.Build();

var solrOperations1 = container.ResolveNamed<ISolrOperations<Dictionary<string, object>>>("entity1");
var solrOperations2 = container.ResolveNamed<ISolrOperations<Dictionary<string, object>>>("entity2");
```

When resolving by name, the Id assigned to each SolrServerElement is the name to use.

As it stands right now this isn't possible with the current implementation.
