### PR TITLE
Added missing parsers to Ninject SolrNetModule.

### DIFF
--- a/Ninject.Integration.SolrNet/SolrNetModule.cs
+++ b/Ninject.Integration.SolrNet/SolrNetModule.cs
@@ -168,6 +168,7 @@ namespace Ninject.Integration.SolrNet {
             Bind<ISolrFieldParser>().To<DefaultFieldParser>();
             Bind(typeof (ISolrDocumentActivator<>)).To(typeof (SolrDocumentActivator<>));
             Bind(typeof(ISolrDocumentResponseParser<>)).To(typeof(SolrDocumentResponseParser<>));
+            Bind<ISolrDocumentResponseParser<Dictionary<string, object>>>().To<SolrDictionaryDocumentResponseParser>();
             Bind<ISolrFieldSerializer>().To<DefaultFieldSerializer>();
             Bind<ISolrQuerySerializer>().To<DefaultQuerySerializer>();
             Bind<ISolrFacetQuerySerializer>().To<DefaultFacetQuerySerializer>();
@@ -183,6 +184,7 @@ namespace Ninject.Integration.SolrNet {
                 Bind<IValidationRule>().To(p);
             Bind(typeof(ISolrMoreLikeThisHandlerQueryResultsParser<>)).To(typeof(SolrMoreLikeThisHandlerQueryResultsParser<>));
             Bind(typeof(ISolrDocumentSerializer<>)).To(typeof(SolrDocumentSerializer<>));
+            Bind(typeof(ISolrDocumentSerializer<Dictionary<string, object>>)).To(typeof(SolrDictionarySerializer));
 
             Bind<ISolrSchemaParser>().To<SolrSchemaParser>();
             Bind<ISolrDIHStatusParser>().To<SolrDIHStatusParser>();


### PR DESCRIPTION
While doing some testing I found that the Ninject module was missing ISolrDocumentSerializer + ISolrDocumentResponseParser for Dictionary<string,object>.

So here they are :) (I check all the others and they were fine)
