### PR TITLE
Changed distance query to take double instead of int

### DIFF
--- a/SolrNet/SolrQueryByDistance.cs
+++ b/SolrNet/SolrQueryByDistance.cs
@@ -62,7 +62,7 @@ namespace SolrNet {
             }
         }
 
-        public int DistanceFromPoint { get; private set; }
+        public double DistanceFromPoint { get; private set; }
 
         /// <summary>
         /// Calculation accuracy
@@ -77,7 +77,7 @@ namespace SolrNet {
         /// <param name="pointLongitude"></param>
         /// <param name="distance"></param>
         [Obsolete("Use the constructor with the Location parameter")]
-        public SolrQueryByDistance(string fieldName, double pointLatitude, double pointLongitude, int distance) : this(fieldName, pointLatitude, pointLongitude, distance, CalculationAccuracy.Radius) {}
+        public SolrQueryByDistance(string fieldName, double pointLatitude, double pointLongitude, double distance) : this(fieldName, pointLatitude, pointLongitude, distance, CalculationAccuracy.Radius) {}
 
         /// <summary>
         /// Query by distance using <see cref="CalculationAccuracy.Radius"/>
@@ -85,9 +85,9 @@ namespace SolrNet {
         /// <param name="fieldName"></param>
         /// <param name="location"></param>
         /// <param name="distance"></param>
-        public SolrQueryByDistance(string fieldName, Location location, int distance) : this(fieldName, location, distance, CalculationAccuracy.Radius) { }
+        public SolrQueryByDistance(string fieldName, Location location, double distance) : this(fieldName, location, distance, CalculationAccuracy.Radius) { }
 
-        public SolrQueryByDistance(string fieldName, Location location, int distance, CalculationAccuracy accuracy) {
+        public SolrQueryByDistance(string fieldName, Location location, double distance, CalculationAccuracy accuracy) {
             if (string.IsNullOrEmpty(fieldName))
                 throw new ArgumentNullException("fieldName");
 
@@ -112,7 +112,7 @@ namespace SolrNet {
         /// <param name="distance"></param>
         /// <param name="accuracy"></param>
         [Obsolete("Use the constructor with the Location parameter")]
-        public SolrQueryByDistance(string fieldName, double pointLatitude, double pointLongitude, int distance, CalculationAccuracy accuracy): this(fieldName, new Location(pointLatitude, pointLongitude), distance, accuracy) {
+        public SolrQueryByDistance(string fieldName, double pointLatitude, double pointLongitude, double distance, CalculationAccuracy accuracy): this(fieldName, new Location(pointLatitude, pointLongitude), distance, accuracy) {
         }
 
         public string Query {


### PR DESCRIPTION
Needed a fix for my project to allow floating point values for distance (which is supported by SOLR). Not sure if there was a valid reason to have it as an int, but I went ahead and changed it to double. All tests pass. I suppose this could potentially break users' unit tests if they are mocking and have expectations/setups that explicitly reference "int" as the type of this param, but I think that's not likely, and an easy fix anyway.
