### PR TITLE
Client certificate implementation of HttpWebRequest

### DIFF
--- a/HttpWebAdapters/Impl/ClientCertificateHttpWebRequestFactory.cs
+++ b/HttpWebAdapters/Impl/ClientCertificateHttpWebRequestFactory.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using HttpWebAdapters.Adapters;
+
+namespace HttpWebAdapters {
+    /// <summary>
+    ///     Creates a web request that uses client certificates
+    /// </summary>
+    public class ClientCertificateHttpWebRequestFactory : IHttpWebRequestFactory {
+        private readonly X509Certificate2 certificate;
+
+        /// <summary>
+        ///     Creates a web request that uses 509 Client Certificates
+        /// </summary>
+        /// <param name="certificate">X5092 Certificate with private key</param>
+        public ClientCertificateHttpWebRequestFactory(X509Certificate2 certificate) {
+            this.certificate = certificate;
+        }
+
+        public IHttpWebRequest Create(Uri url) {
+            var req = (HttpWebRequest) WebRequest.Create(url);
+            req.ClientCertificates.Add(certificate);
+            return new HttpWebRequestAdapter(req);
+        }
+
+        public IHttpWebRequest Create(string url) {
+            return Create(new Uri(url));
+        }
+    }
+}


### PR DESCRIPTION
Nota Bene -- the certificates must be of type X5092 (vs 1) and must also
contain the private key or the request will fail. Be-aware, if you are
using the windows keystore that you may have to give the running process
specific permissions to "Personal" certificate keystore.
