### PR TITLE
Fix for build script paths 

### DIFF
--- a/SampleSolrApp/SampleSolrApp.csproj
+++ b/SampleSolrApp/SampleSolrApp.csproj
@@ -128,7 +128,7 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <!--<Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />-->
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/lib/FAKE.exe.config
+++ b/lib/FAKE.exe.config
@@ -2,7 +2,7 @@
 <configuration>
   <appSettings>
     <add key="MSBuildPath" value="[SystemRoot]\Microsoft.NET\Framework\v4.0.30319\;[SystemRoot]\Microsoft.NET\Framework\v4.0.30128\;[SystemRoot]\Microsoft.NET\Framework\v3.5\" />
-    <add key="FSIPath" value=".\tools\FSharp\;.\lib\FSharp\;[ProgramFiles]\Microsoft F#\v4.0\;[ProgramFilesX86]\Microsoft F#\v4.0\;[ProgramFiles]\FSharp-2.0.0.0\bin\;[ProgramFilesX86]\FSharp-2.0.0.0\bin\;[ProgramFiles]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\FSharp-1.9.9.9\bin\" />
+    <add key="FSIPath" value=".\tools\FSharp\;.\lib\FSharp\;[ProgramFiles]\Microsoft F#\v4.0\;[ProgramFilesX86]\Microsoft F#\v4.0\;[ProgramFiles]\FSharp-2.0.0.0\bin\;[ProgramFilesX86]\FSharp-2.0.0.0\bin\;[ProgramFiles]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\Microsoft SDKs\F#\3.1\Framework\v4.0\" />
     <add key="GitPath" value="[ProgramFilesX86]\Git\bin\;[ProgramFiles]\Git\bin\" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
Super tiny fix but was annoying me :)

Fresh laptop install with VS2013 only and latest FSharp 3 (3.1.1) I found that fake couldn't find FSI correctly, (so ive added an updated location path) and the sample app wouldn't build (via Release.bat) so ive commented out the first line to the webapplication.targets as it seems to always be in the v10 folder so finds it correctly.
