### PR TITLE
Issue 129: Support for providing a custom IHttpWebRequestFactory when using Autofac

### DIFF
--- a/AutofacContrib.SolrNet.Tests/AutofacContrib.SolrNet.Tests.csproj
+++ b/AutofacContrib.SolrNet.Tests/AutofacContrib.SolrNet.Tests.csproj
@@ -64,6 +64,10 @@
       <Project>{931CEB14-556F-4893-A8D9-C7C6DACA444F}</Project>
       <Name>AutofacContrib.SolrNet</Name>
     </ProjectReference>
+    <ProjectReference Include="..\HttpWebAdapters\HttpWebAdapters.csproj">
+      <Project>{AE7D2A46-3F67-4986-B04B-7DCE79A549A5}</Project>
+      <Name>HttpWebAdapters</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SolrNet.Tests\SolrNet.Tests.csproj">
       <Project>{F3FE6EF5-CF5C-4461-8691-4A498A463FD5}</Project>
       <Name>SolrNet.Tests</Name>

--- a/AutofacContrib.SolrNet/AutofacContrib.SolrNet.csproj
+++ b/AutofacContrib.SolrNet/AutofacContrib.SolrNet.csproj
@@ -57,6 +57,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\HttpWebAdapters\HttpWebAdapters.csproj">
+      <Project>{AE7D2A46-3F67-4986-B04B-7DCE79A549A5}</Project>
+      <Name>HttpWebAdapters</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SolrNet\SolrNet.csproj">
       <Project>{CEEB8690-3E08-4440-B647-787A58E71CFA}</Project>
       <Name>SolrNet</Name>


### PR DESCRIPTION
I just followed the same model used in Autofac.Contrib.SolrNet.SolrNetModule to add a custom IReadOnlyMappingManager. I also added a simple test to the unit tests.
