### PR TITLE
fixed the spellcheck parser bug

### DIFF
--- a/SolrNet.Tests/Resources/responseWithSpellChecking.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellChecking.xml
@@ -12,7 +12,9 @@
         <int name="startOffset">0</int>
         <int name="endOffset">4</int>
         <arr name="suggestion">
-          <str>dell</str>
+          <lst>
+            <str>dell</str>
+          </lst>
         </arr>
       </lst>
       <lst name="ultrashar">
@@ -20,7 +22,9 @@
         <int name="startOffset">5</int>
         <int name="endOffset">14</int>
         <arr name="suggestion">
-          <str>ultrasharp</str>
+          <lst>
+            <str>ultrasharp</str>
+          </lst>
         </arr>
       </lst>
       <str name="collation">dell ultrasharp</str>

--- a/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
@@ -56,7 +56,7 @@ namespace SolrNet.Impl.ResponseParsers {
                 result.EndOffset = Convert.ToInt32(c.XPathSelectElement("int[@name='endOffset']").Value);
                 result.StartOffset = Convert.ToInt32(c.XPathSelectElement("int[@name='startOffset']").Value);
                 var suggestions = new List<string>();
-                var suggestionNodes = c.XPathSelectElements("arr[@name='suggestion']/str");
+                var suggestionNodes = c.XPathSelectElements("arr[@name='suggestion']/lst/str");
                 foreach (var suggestionNode in suggestionNodes) {
                     suggestions.Add(suggestionNode.Value);
                 }


### PR DESCRIPTION
The bug comes from the xpath used to get suggestion.

The suggestion is wrapped inside a lst element.
    &lt;arr name=&quot;suggestion&quot;&gt;
      &lt;lst&gt;
        &lt;str&gt;dell&lt;/str&gt;
      &lt;/lst&gt;
    &lt;/arr&gt;

The "arr[@name='suggestion']/str" xpath returns an empty sequence.
