### PR TITLE
Distributed multi server and core wiring

### DIFF
--- a/Castle.Facilities.SolrNetIntegration.Tests/CastleFixture.cs
+++ b/Castle.Facilities.SolrNetIntegration.Tests/CastleFixture.cs
@@ -152,6 +152,44 @@ namespace Castle.Facilities.SolrNetIntegration.Tests {
         }
 
         [Test]
+        public void GetFromOrAddToContainer()
+        {
+            const string core0url = "http://localhost:8983/solr/core0";
+            const string core1url = "http://localhost:8983/solr/core1";
+
+            var container = new WindsorContainer();
+
+            var solrFacility = SolrNetFacility.GetFromOrAddToContainer(container);
+            var existingFacility = SolrNetFacility.GetFromOrAddToContainer(container);
+            Assert.AreSame(solrFacility, existingFacility);
+
+            solrFacility.AddCore("core0-id", typeof(Document), core0url);
+            solrFacility.AddCore("core1-id", typeof(Document), core1url);
+            solrFacility.AddCore("core2-id", typeof(Core1Entity), core1url);            
+
+            TestCores(container);
+        }
+
+        [Test]
+        public void GetFromOrAddToContainerExtension()
+        {
+            const string core0url = "http://localhost:8983/solr/core0";
+            const string core1url = "http://localhost:8983/solr/core1";
+
+            var container = new WindsorContainer();
+
+            var solrFacility = container.GetOrAddSolrNetFacility();
+            var existingFacility = container.GetOrAddSolrNetFacility();
+            Assert.AreSame(solrFacility, existingFacility);
+
+            solrFacility.AddCore("core0-id", typeof(Document), core0url);
+            solrFacility.AddCore("core1-id", typeof(Document), core1url);
+            solrFacility.AddCore("core2-id", typeof(Core1Entity), core1url);
+
+            TestCores(container);
+        }
+
+        [Test]
         public void RegisterCoreAfterFacilityIsAddedToWindsor()
         {
             const string core0url = "http://localhost:8983/solr/core0";

--- a/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.csproj
+++ b/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.csproj
@@ -77,6 +77,7 @@
     <Compile Include="SolrNetFacility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StrictArrayResolver.cs" />
+    <Compile Include="WindsorContainerExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SolrNet\SolrNet.csproj">

--- a/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
+++ b/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
@@ -16,9 +16,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Castle.Core.Configuration;
 using Castle.MicroKernel.Facilities;
 using Castle.MicroKernel.Registration;
+using Castle.Windsor;
 using SolrNet;
 using SolrNet.Exceptions;
 using SolrNet.Impl;
@@ -42,7 +44,21 @@ namespace Castle.Facilities.SolrNetIntegration {
         private readonly string solrURL;
         private bool _addedToSolr;
 
+        /// <summary>
+        /// Fetches an existing facility from windsor or adds a new one if none exists yet.
+        /// </summary>
+        /// <param name="container"></param>
+        /// <returns></returns>
+        public static SolrNetFacility GetFromOrAddToContainer(IWindsorContainer container) {
+            var existingFacility = container.Kernel.GetFacilities().OfType<SolrNetFacility>().SingleOrDefault();
+            if (existingFacility != null) {
+                return existingFacility;
+            }
 
+            var facility = new SolrNetFacility();
+            container.AddFacility(facility);
+            return facility;
+        }
 
         /// <summary>
         /// Default mapper override

--- a/Castle.Facilities.SolrNetIntegration/WindsorContainerExtensions.cs
+++ b/Castle.Facilities.SolrNetIntegration/WindsorContainerExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Castle.Windsor;
+
+namespace Castle.Facilities.SolrNetIntegration {
+    /// <summary>
+    /// Adds extensions for to improve readability and discoverability
+    /// </summary>
+    public static class WindsorContainerExtensions {
+        /// <summary>
+        /// /// Fetches an existing facility from windsor or adds a new one if none exists yet.
+        /// </summary>
+        /// <param name="this"></param>
+        /// <returns></returns>
+        public static SolrNetFacility GetOrAddSolrNetFacility(this IWindsorContainer @this) {
+            return SolrNetFacility.GetFromOrAddToContainer(@this);
+        }
+    }
+}


### PR DESCRIPTION
Hi. 

We are using a number of fundamentally different Solr cores in different services/components that in principle has nothing what so ever to do with each other. 

In the end though, two or more will be be used from composite user interfaces that pulls in components from many services/components into one interface for the user. 

We want each of these components to be able to do their own wiring with no need to take into account any other Solr components that may be running in the same process in the end.

As far as we could tell the existing Windsor SolrNetFacility cannot provide this ability. 
This branch is our progress so far in trying to modify the facility to easily support enabling this scenario. 

It is very much a work in progress but I figure that the sooner we get feedback on the approach we've chosen so far the better. 

Regards /Magnus Lidbom
