### PR TITLE
Multiple collation term support + Solr 5.0 changed collation response format

### DIFF
--- a/SolrNet.Tests/Resources/responseWithSpellChecking2.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellChecking2.xml
@@ -24,6 +24,8 @@
           <str>ultrasharps</str>
         </arr>
       </lst>
+    </lst>
+    <lst name="collations">
       <str name="collation">dell ultrasharp</str>
       <str name="collation">dell ultrasharps</str>
     </lst>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -338,6 +338,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\responseWithStructuredDebugDetails.xml" />
     <EmbeddedResource Include="Resources\responseWithSimpleDebugDetails.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellChecking2.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -482,8 +482,24 @@ namespace SolrNet.Tests {
             var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
             var spellChecking = parser.ParseSpellChecking(docNode);
             Assert.IsNotNull(spellChecking);
-            Assert.AreEqual("dell ultrasharp", spellChecking.Collation);
             Assert.AreEqual(2, spellChecking.Count);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+            Assert.AreEqual(2, spellChecking.Collations.Count);
+        }
+
+        [Test]
+        public void ParseSpellChecking2()
+        {
+            var parser = new SpellCheckResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking2.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.IsNotNull(spellChecking);
+            Assert.AreEqual(2, spellChecking.Count);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+            Assert.AreEqual(2, spellChecking.Collations.Count);
         }
 
         [Test]

--- a/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
@@ -44,10 +44,20 @@ namespace SolrNet.Impl.ResponseParsers {
         /// <returns></returns>
         public SpellCheckResults ParseSpellChecking(XElement node) {
             var r = new SpellCheckResults();
-            var suggestionsNode = node.XPathSelectElement("lst[@name='suggestions']");
-            var collationNode = suggestionsNode.XPathSelectElement("str[@name='collation']");
-            if (collationNode != null)
-                r.Collation = collationNode.Value;
+            var suggestionsNode = node.XPathSelectElement("lst[@name='suggestions']");            
+            IEnumerable<XElement> collationNodes;
+
+            // Solr 5.0+
+            var collationsNode = node.XPathSelectElement("lst[@name='collations']");
+            if (collationsNode != null)    
+                collationNodes = collationsNode.XPathSelectElements("str[@name='collation']");
+            // Solr 4.x and lower
+            else
+                collationNodes = suggestionsNode.XPathSelectElements("str[@name='collation']");            
+
+            foreach (var cn in collationNodes)
+                r.Collations.Add(cn.Value);
+
             var spellChecks = suggestionsNode.Elements("lst");
             foreach (var c in spellChecks) {
                 var result = new SpellCheckResult();

--- a/SolrNet/Impl/SpellCheckResults.cs
+++ b/SolrNet/Impl/SpellCheckResults.cs
@@ -25,7 +25,7 @@ namespace SolrNet.Impl {
         /// <summary>
         /// Suggestion query from spell-checking
         /// </summary>
-        public string Collation { get; set; }
+        public ICollection<string> Collations = new List<string>();
 
         private readonly ICollection<SpellCheckResult> SpellChecks = new List<SpellCheckResult>();
 


### PR DESCRIPTION
In Solr 5.0 they changed the response format of the spellcheck element to include collations as a lst within the spellcheck element instead of directly under the suggestion element. This includes a new test for the new format and backwards compatibility for the old format. Additionally, SolrNet did not support multiple collations and only interpreted the first. Collations were changed into an ICollection<string> and all items parsed out. Both tests for Solr 4.x and 5.0 now include multiple terms and appropriate assertions.

Related pull requests: 
https://github.com/mausch/SolrNet/pull/24
https://github.com/mausch/SolrNet/pull/116
