### PR TITLE
Spellcheck

### DIFF
--- a/SolrNet.Tests/Resources/responseWithExtendedSpellChecking.xml
+++ b/SolrNet.Tests/Resources/responseWithExtendedSpellChecking.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="spellcheck">
+    <lst name="suggestions">
+      <lst name="delll">
+        <int name="numFound">1</int>
+        <int name="startOffset">0</int>
+        <int name="endOffset">5</int>
+        <int name="origFreq">0</int>
+        <arr name="suggestion">
+          <lst>
+            <str name="word">dell</str>
+            <int name="freq">1</int>
+          </lst>
+        </arr>
+      </lst>
+      <lst name="ultra sharp">
+        <int name="numFound">1</int>
+        <int name="startOffset">6</int>
+        <int name="endOffset">17</int>
+        <int name="origFreq">0</int>
+        <arr name="suggestion">
+          <lst>
+            <str name="word">ultrasharp</str>
+            <int name="freq">1</int>
+          </lst>
+        </arr>
+      </lst>
+    </lst>
+    <bool name="correctlySpelled">false</bool>
+    <lst name="collations">
+      <lst name="collation">
+        <str name="collationQuery">dell ultrasharp</str>
+        <int name="hits">1</int>
+        <lst name="misspellingsAndCorrections">
+          <str name="delll">dell</str>
+          <str name="ultra sharp">ultrasharp</str>
+        </lst>
+      </lst>
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/Resources/responseWithSpellChecking.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellChecking.xml
@@ -23,6 +23,9 @@
           <str>ultrasharp</str>
         </arr>
       </lst>
+    </lst>
+    <bool name="correctlySpelled">true</bool>
+    <lst name="collations">
       <str name="collation">dell ultrasharp</str>
     </lst>
   </lst>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -342,6 +342,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\docWithDynamicFields.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithExtendedSpellChecking.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -500,6 +500,8 @@ namespace SolrNet.Tests {
             Assert.IsNotNull(spellChecking);
             Assert.AreEqual("dell ultrasharp", spellChecking.Collation);
             Assert.AreEqual(2, spellChecking.Count);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.First());
+            Assert.AreEqual(true, spellChecking.CorrectlySpelled);
         }
 
         [Test]

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -476,7 +476,23 @@ namespace SolrNet.Tests {
         }
         
         [Test]
-        public void ParseSpellChecking() {
+        public void ParseExtendedSpellChecking() {
+            var parser = new SpellCheckResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithExtendedSpellChecking.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.IsNotNull(spellChecking);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collation);
+            Assert.AreEqual(2, spellChecking.Count);
+            Assert.AreEqual("dell ultrasharp", spellChecking.ExtendedCollations.First().CollationQuery);
+            Assert.AreEqual(1, spellChecking.ExtendedCollations.First().Hits);
+            Assert.AreEqual(new KeyValuePair<string, string>("delll", "dell"), spellChecking.ExtendedCollations.First().MisspellingsAndCorrections.First());
+            Assert.AreEqual(false, spellChecking.CorrectlySpelled);
+        }
+
+        [Test]
+        public void ParseSpellChecking()
+        {
             var parser = new SpellCheckResponseParser<Product>();
             var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking.xml");
             var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");

--- a/SolrNet/Impl/ExtendedSpellCheckCollationResult.cs
+++ b/SolrNet/Impl/ExtendedSpellCheckCollationResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace SolrNet.Impl {
+    /// <summary>
+    /// Spellcheck collation results
+    /// </summary>
+    public class ExtendedSpellCheckCollationResult {
+        /// <summary>
+        /// The new collated query
+        /// </summary>
+        public string CollationQuery { get; set; }
+
+        /// <summary>
+        /// Number of hits that the current collation might return
+        /// </summary>
+        public int Hits { get; set; }
+
+        /// <summary>
+        /// A summary of each correction made
+        /// </summary>
+        public ICollection<KeyValuePair<string, string>> MisspellingsAndCorrections { get; set; }
+    }
+}

--- a/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
@@ -46,9 +46,6 @@ namespace SolrNet.Impl.ResponseParsers {
         public SpellCheckResults ParseSpellChecking(XElement node) {
             var r = new SpellCheckResults();
             var suggestionsNode = node.XPathSelectElement("lst[@name='suggestions']");
-            var collationNode = suggestionsNode.XPathSelectElement("str[@name='collation']");
-            if (collationNode != null)
-                r.Collation = collationNode.Value;
             var spellChecks = suggestionsNode.Elements("lst");
             foreach (var c in spellChecks) {
                 var result = new SpellCheckResult();
@@ -69,7 +66,10 @@ namespace SolrNet.Impl.ResponseParsers {
             r.ExtendedCollations = extendedCollationNodes
                 .Select(ToExtendedCollationResult).ToList();
             
-            r.Collation = r.Collation ?? r.ExtendedCollations.FirstOrDefault()?.CollationQuery;
+            var collationNodes = node.XPathSelectElements("lst[@name='collations']/str[@name='collation']");
+            r.Collations = collationNodes.Select(n => n.Value).ToArray();
+
+            r.Collation = r.Collations.FirstOrDefault() ?? r.ExtendedCollations.FirstOrDefault()?.CollationQuery;
 
             var correctlySpelledNode = node.XPathSelectElement("bool[@name='correctlySpelled']");
             if(correctlySpelledNode != null)

--- a/SolrNet/Impl/SpellCheckResults.cs
+++ b/SolrNet/Impl/SpellCheckResults.cs
@@ -27,8 +27,18 @@ namespace SolrNet.Impl {
         /// </summary>
         public string Collation { get; set; }
 
-        private readonly ICollection<SpellCheckResult> SpellChecks = new List<SpellCheckResult>();
+        /// <summary>
+        /// Extended collated suggestions from spell-checking
+        /// </summary>
+        public ICollection<ExtendedSpellCheckCollationResult> ExtendedCollations = new List<ExtendedSpellCheckCollationResult>();
 
+        /// <summary>
+        /// Whether the original query was correctly spelled
+        /// </summary>
+        public bool? CorrectlySpelled { get; set; }
+
+        private readonly ICollection<SpellCheckResult> SpellChecks = new List<SpellCheckResult>();
+        
         public IEnumerator<SpellCheckResult> GetEnumerator() {
             return SpellChecks.GetEnumerator();
         }

--- a/SolrNet/Impl/SpellCheckResults.cs
+++ b/SolrNet/Impl/SpellCheckResults.cs
@@ -14,8 +14,10 @@
 // limitations under the License.
 #endregion
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.PerformanceData;
 
 namespace SolrNet.Impl {
     /// <summary>
@@ -23,7 +25,8 @@ namespace SolrNet.Impl {
     /// </summary>
     public class SpellCheckResults : ICollection<SpellCheckResult> {
         /// <summary>
-        /// Suggestion query from spell-checking
+        /// First founs suggestion query from spell-checking
+        /// Works if request was for extended and non-extended collation results
         /// </summary>
         public string Collation { get; set; }
 
@@ -31,6 +34,11 @@ namespace SolrNet.Impl {
         /// Extended collated suggestions from spell-checking
         /// </summary>
         public ICollection<ExtendedSpellCheckCollationResult> ExtendedCollations = new List<ExtendedSpellCheckCollationResult>();
+
+        /// <summary>
+        /// Collated query suggestions from spell-checking
+        /// </summary>
+        public ICollection<string> Collations = new List<string>();
 
         /// <summary>
         /// Whether the original query was correctly spelled

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Impl\ResponseParsers\ReplicationDetailsResponseParser.cs" />
     <Compile Include="Impl\ResponseParsers\ReplicationIndexVersionResponseParser.cs" />
     <Compile Include="Impl\ResponseParsers\ReplicationStatusResponseParser.cs" />
+    <Compile Include="Impl\ExtendedSpellCheckCollationResult.cs" />
     <Compile Include="ISolrCoreReplication.cs" />
     <Compile Include="Impl\SolrCoreReplication.cs" />
     <Compile Include="Impl\FieldParsers\DateTimeOffsetFieldParser.cs" />


### PR DESCRIPTION
Tested against Solr v6.1.0, but I noticed that we have had a work around for this since over a year ago, and also, the documentation online does not show the originally tested schema. Let me know if I need to still make it backwards compatible.
