### PR TITLE
Update StructureMap to 4.5.2, with help of PR #186

### DIFF
--- a/StructureMap.SolrNetIntegration.Tests/StructureMap.SolrNetIntegration.Tests.csproj
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMap.SolrNetIntegration.Tests.csproj
@@ -55,8 +55,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StructureMap, Version=2.6.2.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.2.6.2\lib\StructureMap.dll</HintPath>
+    <Reference Include="StructureMap, Version=4.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StructureMap.4.5.2\lib\net45\StructureMap.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
@@ -10,11 +10,19 @@ namespace StructureMap.SolrNetIntegration.Tests {
     [Trait("Category","Integration")]
     public class StructureMapIntegrationFixture {
 
+        private readonly IContainer Container;
+
+        public StructureMapIntegrationFixture()
+        {
+            var solrConfig = (SolrConfigurationSection)ConfigurationManager.GetSection("solr");
+            Container = new Container (c => c.IncludeRegistry(new SolrNetRegistry(solrConfig.SolrServers)));
+        }
+
+
         [Fact]
         public void Ping_And_Query()
         {
-            SetupContainer();
-            var solr = ObjectFactory.GetInstance<ISolrOperations<Entity>>();
+            var solr = Container.GetInstance<ISolrOperations<Entity>>();
             solr.Ping();
             Console.WriteLine(solr.Query(SolrQuery.All).Count);
         }
@@ -22,9 +30,8 @@ namespace StructureMap.SolrNetIntegration.Tests {
         [Fact]
         public void DictionaryDocument()
         {
-            SetupContainer();
 
-            var solr = ObjectFactory.Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
+            var solr = Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
             var results = solr.Query(SolrQuery.All);
             Assert.True (results.Count > 0);
             foreach (var d in results)
@@ -38,9 +45,8 @@ namespace StructureMap.SolrNetIntegration.Tests {
         [Fact]
         public void DictionaryDocument_add()
         {
-            SetupContainer();
 
-            var solr = ObjectFactory.Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
+            var solr = Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
 
             solr.Add(new Dictionary<string, object> 
             {
@@ -51,11 +57,6 @@ namespace StructureMap.SolrNetIntegration.Tests {
             });
         }
 
-        private static void SetupContainer()
-        {
-            var solrConfig = (SolrConfigurationSection)ConfigurationManager.GetSection("solr");
-            ObjectFactory.Initialize(c => c.IncludeRegistry(new SolrNetRegistry(solrConfig.SolrServers)));
-        }
-
+       
     }
 }

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapMultiCoreFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapMultiCoreFixture.cs
@@ -10,10 +10,13 @@ namespace StructureMap.SolrNetIntegration.Tests
 
     public class StructureMapMultiCoreFixture
     {
+
+        private readonly IContainer Container;
         public StructureMapMultiCoreFixture()
         {
             var solrConfig = (SolrConfigurationSection)ConfigurationManager.GetSection("solr");
-            ObjectFactory.Initialize(c =>
+
+            Container = new Container(c=> 
             {
                 c.Scan(s =>
                 {
@@ -28,22 +31,24 @@ namespace StructureMap.SolrNetIntegration.Tests
         [Fact]
         public void Get_SolrOperations_for_Entity()
         {
-            var solrOperations = ObjectFactory.Container.GetInstance<ISolrOperations<Entity>>();
+            var solrOperations = Container.GetInstance<ISolrOperations<Entity>>();
             Assert.NotNull(solrOperations);
         }
 
         [Fact]
         public void Get_SolrOperations_for_Entity2()
         {
-            var solrOperations2 = ObjectFactory.Container.GetInstance<ISolrOperations<Entity2>>("entity2");
+            var solrOperations2 = Container.GetInstance<ISolrOperations<Entity2>>("entity2");
             Assert.NotNull(solrOperations2);
         }
 
         [Fact]
         public void Same_document_type_different_core_url()
         {
-            var core1 = ObjectFactory.Container.GetInstance<ISolrOperations<Entity2>>("entity2");
-            var core2 = ObjectFactory.Container.GetInstance<ISolrOperations<Entity2>>("entity3");
+            var core1 = Container.GetInstance<ISolrOperations<Entity2>>("entity2");
+            var core2 = Container.GetInstance<ISolrOperations<Entity2>>("entity3");
         }
+
+
     }
 }

--- a/StructureMap.SolrNetIntegration.Tests/packages.config
+++ b/StructureMap.SolrNetIntegration.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="structuremap" version="2.6.2" targetFramework="net46" />
+  <package id="StructureMap" version="4.5.2" targetFramework="net46" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net46" />
   <package id="xunit" version="2.2.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net46" />

--- a/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.csproj
+++ b/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.csproj
@@ -57,8 +57,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StructureMap, Version=2.6.2.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.2.6.2\lib\StructureMap.dll</HintPath>
+    <Reference Include="StructureMap, Version=4.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StructureMap.4.5.2\lib\net45\StructureMap.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -106,8 +106,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="StructureMap.SolrNetIntegration.nuspec" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.nuspec
+++ b/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.nuspec
@@ -13,7 +13,7 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="SolrNet" version="[0.7.1]" />
-      <dependency id="StructureMap" version="2.6.2" />
+      <dependency id="StructureMap" version="4.5.2" />
     </dependencies>
   </metadata>
   <files>

--- a/StructureMap.SolrNetIntegration/packages.config
+++ b/StructureMap.SolrNetIntegration/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="structuremap" version="2.6.2" targetFramework="net46" />
+  <package id="StructureMap" version="4.5.2" targetFramework="net46" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Update unit tests, and integration tests. 
The integration tests that fail, also used to fail, so that's ok.

As never have used StructureMap, I used PR #186, that deals with updating to StructureMap 3, to make the changes. So knowing the changes are the same, and the unit tests pass, I'm confident about this PR.