### PR TITLE
Add netstandard 2.0 support for SolrNet.Cloud

### DIFF
--- a/AutofacContrib.SolrNet/AutofacContrib.SolrNet.nuspec
+++ b/AutofacContrib.SolrNet/AutofacContrib.SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Autofac</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.Autofac</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>Autofac module for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="Autofac" version="4.6.1" />
     </dependencies>
   </metadata>

--- a/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.nuspec
+++ b/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Windsor</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.Windsor</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>Windsor facility for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="Castle.Core" version="4.1.1" />
       <dependency id="Castle.Windsor" version="4.0.0" />
     </dependencies>

--- a/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.csproj
+++ b/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.csproj
@@ -35,17 +35,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeper.Net.3.4.6.2\lib\net40\ZooKeeperNet.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />

--- a/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.nuspec
+++ b/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Cloud</id>
-    <version>0.7.1-beta</version>
+    <version>0.8.1-beta</version>
     <title>SolrNet</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -13,7 +13,7 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="CommonServiceLocator" version="1.3" />
-      <dependency id="SolrNet.Cloud" version="[0.7.1-beta]" />
+      <dependency id="SolrNet.Cloud" version="[0.8.1-beta]" />
     </dependencies>
   </metadata>
   <files>

--- a/CommonServiceLocator.SolrNet.Cloud/Properties/AssemblyInfo.cs
+++ b/CommonServiceLocator.SolrNet.Cloud/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]
+[assembly: AssemblyVersion("0.8.1.0")]
+[assembly: AssemblyFileVersion("0.8.1.0")]

--- a/CommonServiceLocator.SolrNet.Cloud/packages.config
+++ b/CommonServiceLocator.SolrNet.Cloud/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
-  <package id="log4net" version="2.0.8" targetFramework="net46" />
-  <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net46" />
 </packages>

--- a/CommonServiceLocator.SolrNet/CommonServiceLocator.SolrNet.nuspec
+++ b/CommonServiceLocator.SolrNet/CommonServiceLocator.SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -13,7 +13,7 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="CommonServiceLocator" version="1.3" />
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
     </dependencies>
   </metadata>
   <files>

--- a/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.nuspec
+++ b/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Microsoft.DependencyInjection</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.Microsoft.DependencyInjection</title>
     <authors>Gidon Junge and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>SolrNet extensions for Microsoft.Extensions.DependencyInjection</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
     </dependencies>
   </metadata>

--- a/NHibernate.SolrNet/NHibernate.SolrNet.nuspec
+++ b/NHibernate.SolrNet/NHibernate.SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.NHibernate</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.NHibernate</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>NHibernate integration for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="NHibernate" version="3.2.0.4000" />
     </dependencies>
   </metadata>

--- a/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.nuspec
+++ b/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Ninject</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.Ninject</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>Ninject module for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="Ninject" version="3.2.2.0" />
     </dependencies>
   </metadata>

--- a/SolrNet.Cloud.Tests/FakeProvider.cs
+++ b/SolrNet.Cloud.Tests/FakeProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SolrNet.Cloud.Tests
 {
@@ -14,6 +15,11 @@ namespace SolrNet.Cloud.Tests
         }
 
         public void Dispose() {
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         public SolrCloudState GetCloudState() {
@@ -52,7 +58,8 @@ namespace SolrNet.Cloud.Tests
                 });
         }
 
-        public void Init() {
+        public Task InitAsync() {
+            return Task.CompletedTask;
         }
 
         public ISolrBasicOperations<T> GetBasicOperations<T>(string url, bool isPostConnection = false)

--- a/SolrNet.Cloud.Tests/SolrNet.Cloud.Tests.csproj
+++ b/SolrNet.Cloud.Tests/SolrNet.Cloud.Tests.csproj
@@ -67,8 +67,8 @@
     <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
-    <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeper.Net.3.4.6.2\lib\net40\ZooKeeperNet.dll</HintPath>
+    <Reference Include="ZooKeeperNetEx, Version=3.4.9.4, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.9.4\lib\net45\ZooKeeperNetEx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SolrNet.Cloud.Tests/StartupTests.cs
+++ b/SolrNet.Cloud.Tests/StartupTests.cs
@@ -4,6 +4,7 @@ using SolrNet.Cloud.ZooKeeperClient;
 using SolrNet.Commands.Parameters;
 using SolrNet.Impl;
 using SolrNet.Impl.ResponseParsers;
+using System.Threading.Tasks;
 
 namespace SolrNet.Cloud.Tests
 {
@@ -27,18 +28,19 @@ namespace SolrNet.Cloud.Tests
             }            
         }
 
-        public StartupTests()
+        public async Task PrepareContainerAsync()
         {
             var collectionNames = new[] { "data", "hosts" };
             PrepareCollections(collectionNames);            
 
-            Startup.Init<FakeEntity>(new SolrCloudStateProvider("127.0.0.1:9983"), collectionNames[0], true);
-            Startup.Init<FakeEntity1>(new SolrCloudStateProvider("127.0.0.1:9983"), collectionNames[1]);
+        await    Startup.InitAsync<FakeEntity>(new SolrCloudStateProvider("127.0.0.1:9983"), collectionNames[0], true);
+        await    Startup.InitAsync<FakeEntity1>(new SolrCloudStateProvider("127.0.0.1:9983"), collectionNames[1]);
         }
 
         [Fact]
-        public void ShouldResolveBasicOperationsFromStartupContainer()
+        public async Task ShouldResolveBasicOperationsFromStartupContainer()
         {
+            await PrepareContainerAsync();
             Assert.NotNull(
                 Startup.Container.GetInstance<ISolrBasicOperations<FakeEntity>>());
 
@@ -50,28 +52,33 @@ namespace SolrNet.Cloud.Tests
         }
 
         [Fact]
-        public void ShouldResolveBasicReadOnlyOperationsFromStartupContainer()
+        public async Task ShouldResolveBasicReadOnlyOperationsFromStartupContainer()
         {
+            await PrepareContainerAsync();
+
             Assert.NotNull(
                 Startup.Container.GetInstance<ISolrBasicReadOnlyOperations<FakeEntity>>());
         }
 
 
         [Fact]
-        public void ShouldResolveOperationsFromStartupContainer() {
+        public async Task ShouldResolveOperationsFromStartupContainer() {
+
+            await PrepareContainerAsync();
             Assert.NotNull(
                 Startup.Container.GetInstance<ISolrOperations<FakeEntity>>());
         }
 
         [Fact]
-        public void ShouldResolveOperationsProviderFromStartupContainer()
+        public async Task ShouldResolveOperationsProviderFromStartupContainer()
         {
+            await PrepareContainerAsync();
             Assert.NotNull(
                 Startup.Container.GetInstance<ISolrOperationsProvider>());
         }
 
         [Fact]
-        public void ShouldResolveReadOnlyOperationsFromStartupContainer()
+        public async Task ShouldResolveReadOnlyOperationsFromStartupContainer()
         {
             Assert.NotNull(
                 Startup.Container.GetInstance<ISolrReadOnlyOperations<FakeEntity>>());

--- a/SolrNet.Cloud.Tests/packages.config
+++ b/SolrNet.Cloud.Tests/packages.config
@@ -9,5 +9,5 @@
   <package id="xunit.core" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
-  <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net46" />
+  <package id="ZooKeeperNetEx" version="3.4.9.4" targetFramework="net46" />
 </packages>

--- a/SolrNet.Cloud/CollectionsAdmin/SolrCollectionsAdmin.cs
+++ b/SolrNet.Cloud/CollectionsAdmin/SolrCollectionsAdmin.cs
@@ -440,20 +440,20 @@ namespace SolrNet.Cloud.CollectionsAdmin {
 
         public static OverseerStatusClass Parse(string jsonString)
         {
-            var jobject = JValue.Parse(jsonString);
+            var jobject = JToken.Parse(jsonString);
             var overseerStatus = jobject.ToObject<OverseerStatusClass>();
-            var jobjectDynamic = JValue.Parse(jsonString) as dynamic;
+            
+            overseerStatus.OverseerOperations = ParseOperationDict( jobject["overseer_operations"]);
+            overseerStatus.CollectionOperations = ParseOperationDict(jobject["collection_operations"]);
+            overseerStatus.OverseerQueue = ParseOperationDict(jobject["overseer_queue"]);
+            overseerStatus.OverseerInternalQueue = ParseOperationDict(jobject["overseer_internal_queue"]);
+            overseerStatus.CollectionQueue = ParseOperationDict(jobject["collection_queue"]);
 
-            overseerStatus.OverseerOperations = ParseOperationDict(jobjectDynamic.overseer_operations);
-            overseerStatus.CollectionOperations = ParseOperationDict(jobjectDynamic.collection_operations);
-            overseerStatus.OverseerQueue = ParseOperationDict(jobjectDynamic.overseer_queue);
-            overseerStatus.OverseerInternalQueue = ParseOperationDict(jobjectDynamic.overseer_internal_queue);
-            overseerStatus.CollectionQueue = ParseOperationDict(jobjectDynamic.collection_queue);
 
             return overseerStatus;
         }
 
-        private static Dictionary<string, OverseerOperationsClass> ParseOperationDict(JArray operationJArray)
+        private static Dictionary<string, OverseerOperationsClass> ParseOperationDict(JToken operationJArray)
         {
             var operationsDict = new Dictionary<string, OverseerOperationsClass>();
             string operationType = null;

--- a/SolrNet.Cloud/ISolrCloudStateProvider.cs
+++ b/SolrNet.Cloud/ISolrCloudStateProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace SolrNet.Cloud
 {
@@ -6,6 +7,7 @@ namespace SolrNet.Cloud
     /// Solr cloud state provider interface
     /// </summary>
     public interface ISolrCloudStateProvider : IDisposable {
+        
         /// <summary>
         /// Provider key
         /// </summary>
@@ -19,6 +21,8 @@ namespace SolrNet.Cloud
         /// <summary>
         /// Provider initialization
         /// </summary>
-        void Init();
+        Task InitAsync();
+
+        Task DisposeAsync();
     }
 }

--- a/SolrNet.Cloud/Properties/AssemblyInfo.cs
+++ b/SolrNet.Cloud/Properties/AssemblyInfo.cs
@@ -2,16 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("SolrNet.Cloud")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("SolrNet.Cloud")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -20,15 +10,3 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bae496f3-2846-4aac-a228-98f5a6952bb8")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]

--- a/SolrNet.Cloud/SolrNet.Cloud.csproj
+++ b/SolrNet.Cloud/SolrNet.Cloud.csproj
@@ -1,99 +1,47 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{BDA98C34-3B00-4B1F-B850-9C776FEDE8E3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SolrNet.Cloud</RootNamespace>
-    <AssemblyName>SolrNet.Cloud</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Version>0.7.1-beta</Version>
+    <Authors>Mauricio Scheffer and contributors</Authors>
+    <Company />
+    <Product>SolrNet.Cloud.Core</Product>
+    <Description>Apache SolrCloud client</Description>
+    <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\SolrNet.Cloud.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\SolrNet.Cloud.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
+    <DocumentationFile>bin\Release\net46\SolrNet.Cloud.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
+    <DocumentationFile>bin\Debug\net46\SolrNet.Cloud.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <!-- NET 4.6 STUFF: -->
   <ItemGroup>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="ZooKeeperNetEx" Version="3.4.9.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+  
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
-    <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeper.Net.3.4.6.2\lib\net40\ZooKeeperNet.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CollectionsAdmin\SolrCollectionsAdmin.cs" />
-    <Compile Include="CollectionsAdmin\ISolrCollectionsAdmin.cs" />
-    <Compile Include="ISolrCloudStateProvider.cs" />
-    <Compile Include="ISolrOperationsProvider.cs" />
-    <Compile Include="MurMurHash3.cs" />
-    <Compile Include="SolrCloudBasicOperations.cs" />
-    <Compile Include="SolrCloudOperationsBase.cs" />
-    <Compile Include="SolrCloudState.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SolrCloudOperations.cs" />
-    <Compile Include="SolrCloudStateParser.cs" />
-    <Compile Include="SolrCloudReplica.cs" />
-    <Compile Include="SolrCloudShard.cs" />
-    <Compile Include="SolrCloudCollection.cs" />
-    <Compile Include="SolrCloudRouter.cs" />
-    <Compile Include="ZooKeeperClient\SolrCloudStateProvider.cs" />
+    <ProjectReference Include="..\SolrNet\SolrNet.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
-    <None Include="SolrNet.Cloud.nuspec" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\SolrNet\SolrNet.csproj">
-      <Project>{ceeb8690-3e08-4440-b647-787a58e71cfa}</Project>
-      <Name>SolrNet</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+ 
+
 </Project>

--- a/SolrNet.Cloud/SolrNet.Cloud.nuspec
+++ b/SolrNet.Cloud/SolrNet.Cloud.nuspec
@@ -2,19 +2,42 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>SolrNet.Cloud.Core</id>
-    <version>0.7.1-beta</version>
+    <version>0.8.1-beta</version>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</licenseUrl>
     <projectUrl>https://github.com/SolrNet/SolrNet</projectUrl>
     <description>Apache SolrCloud client</description>
+    <repository type="git" url="https://github.com/solrnet/solrnet" />
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="SolrNet" version="0.8.1" exclude="Build,Analyzers" />
+        <dependency id="ZooKeeperNetEx" version="3.4.9.4" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="SolrNet" version="0.8.1" exclude="Build,Analyzers" />
+        <dependency id="ZooKeeperNetEx" version="3.4.9.4" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+      </group>
     </dependencies>
+    
   </metadata>
+  <frameworkAssemblies>
+    <frameworkAssembly assemblyName="System.configuration" targetFramework=".NETFramework4.6" />
+    <frameworkAssembly assemblyName="System.Data" targetFramework=".NETFramework4.6" />
+    <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6" />
+    <frameworkAssembly assemblyName="System.Web" targetFramework=".NETFramework4.6" />
+    <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.6" />
+    <frameworkAssembly assemblyName="System.Xml.Linq" targetFramework=".NETFramework4.6" />
+  </frameworkAssemblies>
   <files>
-    <file src="bin\release\SolrNet.Cloud.dll" target="lib\net46\SolrNet.Cloud.dll" />
-    <file src="bin\release\SolrNet.Cloud.pdb" target="lib\net46\SolrNet.Cloud.pdb" />
+    <file src="lib\net46\SolrNet.Cloud.dll" target="lib\net46\SolrNet.Cloud.dll" />
+    <file src="lib\net46\SolrNet.Cloud.xml" target="lib\net46\SolrNet.Cloud.xml" />
+    <file src="lib\net46\SolrNet.Cloud.pdb" target="lib\net46\SolrNet.Cloud.pdb" />
+    <file src="lib\netstandard2.0\SolrNet.Cloud.dll" target="lib\netstandard2.0\SolrNet.Cloud.dll" />
+    <file src="lib\netstandard2.0\SolrNet.Cloud.xml" target="lib\netstandard2.0\SolrNet.Cloud.xml" />
+    <file src="lib\netstandard2.0\SolrNet.Cloud.pdb" target="lib\netstandard2.0\SolrNet.Cloud.pdb" />
   </files>
 </package>

--- a/SolrNet.Cloud/packages.config
+++ b/SolrNet.Cloud/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
-  <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net46" />
+  <package id="ZooKeeperNetEx" version="3.4.9.4" targetFramework="net46" />
 </packages>

--- a/SolrNet.Tests.Integration/Playground.cs
+++ b/SolrNet.Tests.Integration/Playground.cs
@@ -4,19 +4,23 @@ using SolrNet.Attributes;
 using SolrNet.Cloud.ZooKeeperClient;
 using CloudStartup = SolrNet.Cloud.Startup;
 using Xunit;
+using System.Threading.Tasks;
+
 namespace SolrNet.Unity.Tests
 {
     [Trait("Category", "Integration")]
     public class Test
     {
         [Fact]
-        public void TestSorlCloud() {
-            using (var provider = new SolrCloudStateProvider("10.26.11.30:9983")) {
-                CloudStartup.Init<TestEntity>(provider);
+        public async Task TestSorlCloud()
+        {
+            using (var provider = new SolrCloudStateProvider("10.26.11.30:9983"))
+            {
+                await CloudStartup.InitAsync<TestEntity>(provider);
                 TestRoutine();
             }
         }
-    
+
         public void TestRoutine()
         {
             var num = 1000;
@@ -52,12 +56,11 @@ namespace SolrNet.Unity.Tests
 
 
         [Fact]
-        public void AddRemoveTest()
+        public async Task AddRemoveTest()
         {
             const int DocumentCount = 1000;
             const string ZooKeeperConnection = "10.26.11.30:9983";
-
-            CloudStartup.Init<TestEntity>(new SolrCloudStateProvider(ZooKeeperConnection));
+            await CloudStartup.InitAsync<TestEntity>(new SolrCloudStateProvider(ZooKeeperConnection));
             var operations = CloudStartup.Container.GetInstance<ISolrOperations<TestEntity>>();
 
             operations.Delete(SolrQuery.All);
@@ -73,7 +76,8 @@ namespace SolrNet.Unity.Tests
         }
     }
 
-    public class TestEntity {
+    public class TestEntity
+    {
         [SolrField("id")]
         public string Id { get; set; }
 

--- a/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
+++ b/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
@@ -61,8 +61,8 @@
     <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
-    <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeper.Net.3.4.6.2\lib\net40\ZooKeeperNet.dll</HintPath>
+    <Reference Include="ZooKeeperNetEx, Version=3.4.9.4, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.9.4\lib\net45\ZooKeeperNetEx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SolrNet.Tests.Integration/packages.config
+++ b/SolrNet.Tests.Integration/packages.config
@@ -10,5 +10,5 @@
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
   <package id="xunit.runner.console" version="2.2.0" targetFramework="net46" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net46" />
+  <package id="ZooKeeperNetEx" version="3.4.9.4" targetFramework="net46" />
 </packages>

--- a/SolrNet/SolrNet.nuspec
+++ b/SolrNet/SolrNet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>SolrNet.Core</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.nuspec
+++ b/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.StructureMap</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.StructureMap</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>StructureMap registry for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="StructureMap" version="4.5.2" />
     </dependencies>
   </metadata>

--- a/Unity.SolrNetCloudIntegration/Collections/CollectionResolutionExtension.cs
+++ b/Unity.SolrNetCloudIntegration/Collections/CollectionResolutionExtension.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Practices.Unity;
+using Microsoft.Practices.Unity.ObjectBuilder;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unity.SolrNetCloudIntegration.Collections
+{
+    public class CollectionResolutionExtension : UnityContainerExtension
+    {
+        protected override void Initialize()
+        {
+            Container.RegisterType<ResolverOverrideExtractor, CoupledToImplementationDetailsOverrideExtractor>();
+
+            // PreCreation is the wrong stage, should be Creation. But the DynamicMethodConstructorStrategy
+            // will receive the request for resolve prior to the CollectionResolutionStrategy and raise
+            // an exception for trying to construct an interface. There is no way to insert a strategy at the
+            // beginning of a stage as the StagedStrategyChain is append only. Thats the reason why the ArrayResolutionStrategy
+            // is added as first strategy in the Creation stage.
+            Context.Strategies.AddNew<CollectionResolutionStrategy>(UnityBuildStage.PreCreation);
+        }
+    }
+}

--- a/Unity.SolrNetCloudIntegration/Collections/CollectionResolutionStrategy.cs
+++ b/Unity.SolrNetCloudIntegration/Collections/CollectionResolutionStrategy.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Practices.ObjectBuilder2;
+using Microsoft.Practices.Unity;
+using Microsoft.Practices.Unity.Utility;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Unity.SolrNetCloudIntegration.Collections
+{
+    public class CollectionResolutionStrategy : BuilderStrategy
+    {
+        private static readonly MethodInfo genericResolveCollectionMethod = typeof(CollectionResolutionStrategy)
+                .GetMethod("ResolveCollection", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+        private delegate object CollectionResolver(IBuilderContext context);
+
+        public override void PreBuildUp(IBuilderContext context)
+        {
+            Guard.ArgumentNotNull(context, "context");
+
+            Type typeToBuild = context.BuildKey.Type;
+
+            if (typeToBuild.IsGenericType)
+            {
+                Type openGeneric = typeToBuild.GetGenericTypeDefinition();
+
+                if (openGeneric == typeof(IEnumerable<>) ||
+                    openGeneric == typeof(ICollection<>) ||
+                    openGeneric == typeof(IList<>))
+                {
+                    Type elementType = typeToBuild.GetGenericArguments()[0];
+
+                    MethodInfo resolverMethod = genericResolveCollectionMethod.MakeGenericMethod(elementType);
+
+                    CollectionResolver resolver = (CollectionResolver)Delegate.CreateDelegate(typeof(CollectionResolver), resolverMethod);
+
+                    context.Existing = resolver(context);
+                    context.BuildComplete = true;
+                }
+            }
+        }
+
+        private static object ResolveCollection<T>(IBuilderContext context)
+        {
+            IUnityContainer container = context.NewBuildUp<IUnityContainer>();
+
+            var extractor = context.NewBuildUp<ResolverOverrideExtractor>();
+
+            var resolverOverrides = extractor.ExtractResolverOverrides(context);
+
+            List<T> results = new List<T>(container.ResolveAll<T>(resolverOverrides));
+
+            return results;
+        }
+    }
+}

--- a/Unity.SolrNetCloudIntegration/Collections/CoupledToImplementationDetailsOverrideExtractor.cs
+++ b/Unity.SolrNetCloudIntegration/Collections/CoupledToImplementationDetailsOverrideExtractor.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Practices.ObjectBuilder2;
+using Microsoft.Practices.Unity;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unity.SolrNetCloudIntegration.Collections
+{
+    public class CoupledToImplementationDetailsOverrideExtractor : ResolverOverrideExtractor
+    {
+        [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:ElementsMustAppearInTheCorrectOrder",
+            Justification = "Reviewed. Suppression is OK here.")]
+        private static class FieldNames
+        {
+            /// <summary>resolverOverrides</summary>
+            public const string ResolverOverrides = "resolverOverrides";
+        }
+
+        public override ResolverOverride[] ExtractResolverOverrides(IBuilderContext context)
+        {
+            // this method is tightly coupled to the implementation of IBuilderContext. It assumes that the 
+            // class BuilderContext is used and that a field of type CompositeResolverOverride named 'resolverOverrides'
+            // exists in that class
+            ResolverOverride[] resolverOverrides = new ResolverOverride[0];
+
+            if (!(context is BuilderContext))
+            {
+                return resolverOverrides;
+            }
+
+            FieldInfo field = typeof(BuilderContext).GetField(
+                FieldNames.ResolverOverrides, BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (field == null)
+            {
+                return resolverOverrides;
+            }
+
+            var overrides = field.GetValue(context) as IEnumerable<ResolverOverride>;
+
+            if (overrides != null)
+            {
+                resolverOverrides = overrides.ToArray();
+            }
+
+            return resolverOverrides;
+        }
+    }
+}

--- a/Unity.SolrNetCloudIntegration/Collections/NullResolverOverrideExtractor.cs
+++ b/Unity.SolrNetCloudIntegration/Collections/NullResolverOverrideExtractor.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Practices.ObjectBuilder2;
+using Microsoft.Practices.Unity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unity.SolrNetCloudIntegration.Collections
+{
+    public class NullResolverOverrideExtractor : ResolverOverrideExtractor
+    {
+        public override ResolverOverride[] ExtractResolverOverrides(IBuilderContext context)
+        {
+            return new ResolverOverride[0];
+        }
+    }
+}

--- a/Unity.SolrNetCloudIntegration/Collections/ResolverOverrideExtractor.cs
+++ b/Unity.SolrNetCloudIntegration/Collections/ResolverOverrideExtractor.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Practices.ObjectBuilder2;
+using Microsoft.Practices.Unity;
+
+namespace Unity.SolrNetCloudIntegration.Collections
+{
+    public abstract class ResolverOverrideExtractor
+    {
+        public abstract ResolverOverride[] ExtractResolverOverrides(IBuilderContext context);
+    }
+}

--- a/Unity.SolrNetCloudIntegration/Properties/AssemblyInfo.cs
+++ b/Unity.SolrNetCloudIntegration/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]
+[assembly: AssemblyVersion("0.8.1.0")]
+[assembly: AssemblyFileVersion("0.8.1.0")]

--- a/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.csproj
+++ b/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,10 +47,37 @@
     <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Nito.AsyncEx, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Concurrent, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Enlightenment, Version=4.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.4.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="ZooKeeperNetEx, Version=3.4.9.4, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.9.4\lib\net45\ZooKeeperNetEx.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\CollectionResolutionExtension.cs" />
+    <Compile Include="Collections\CollectionResolutionStrategy.cs" />
+    <Compile Include="Collections\CoupledToImplementationDetailsOverrideExtractor.cs" />
+    <Compile Include="Collections\NullResolverOverrideExtractor.cs" />
+    <Compile Include="Collections\ResolverOverrideExtractor.cs" />
     <Compile Include="SolrNetContainerConfiguration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -64,10 +93,19 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="Unity.SolrNetCloudIntegration.nuspec" />
+    <None Include="Unity.SolrNetCloudIntegration.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.nuspec
+++ b/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Cloud.Unity</id>
-    <version>0.7.1-beta</version>
+    <version>0.8.1-beta</version>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
     <licenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</licenseUrl>
@@ -12,7 +12,9 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="Unity" version="4.0.1" />
-      <dependency id="SolrNet.Cloud" version="[0.7.1-beta]" />
+      <dependency id="SolrNet.Cloud" version="[0.8.1-beta]" />
+      <dependency id="ZooKeeperNetEx" version="3.4.9.4" />
+      <dependency id="Nito.AsyncEx" version="4.0.1"/>
     </dependencies>
   </metadata>
   <files>

--- a/Unity.SolrNetCloudIntegration/packages.config
+++ b/Unity.SolrNetCloudIntegration/packages.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
+  <package id="Nito.AsyncEx" version="4.0.1" targetFramework="net46" />
   <package id="Unity" version="4.0.1" targetFramework="net46" />
+  <package id="ZooKeeperNetEx" version="3.4.9.4" targetFramework="net46" />
 </packages>

--- a/Unity.SolrNetIntegration/Unity.SolrNetIntegration.nuspec
+++ b/Unity.SolrNetIntegration/Unity.SolrNetIntegration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Unity</id>
-    <version>0.7.1</version>
+    <version>0.8.1</version>
     <title>SolrNet.Unity</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -12,7 +12,7 @@
     <description>Unity integration for SolrNet</description>
     <language>en-US</language>
     <dependencies>
-      <dependency id="SolrNet.Core" version="[0.7.1]" />
+      <dependency id="SolrNet.Core" version="[0.8.1]" />
       <dependency id="Unity" version="4.0.1" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
* Moved from ZookeeperNet to ZookeeperNetEx
* Made Init of SolrCloudStateProvider async
* Bumped versions to 0.8.1

I kind of worked blindely, has to be tested by somebody that has a SolrCloud setup.
The Dispose method of SolrCloudStateProvider currently contains an non-awaited async call, which is don't really like, but currently have no other solution.

