### PR TITLE
Fixing parsing problems in spellcheck #310

### DIFF
--- a/SolrNet.Tests/Resources/responseWithSpellCheckingExpandedCollationInCollations.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellCheckingExpandedCollationInCollations.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <response>
-  <lst name="responseHeader">
-    <int name="status">0</int>
-    <int name="QTime">10</int>
-  </lst>
-  <result name="response" start="0" numFound="0"/>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
   <lst name="spellcheck">
     <lst name="suggestions">
       <lst name="delll">
@@ -15,22 +15,18 @@
         <arr name="suggestion">
           <lst>
             <str name="word">dell</str>
-            <int name="freq">2</int>
+            <int name="freq">1</int>
           </lst>
         </arr>
       </lst>
-      <lst name="mxtor">
-        <int name="numFound">2</int>
+      <lst name="ultra sharp">
+        <int name="numFound">1</int>
         <int name="startOffset">6</int>
-        <int name="endOffset">11</int>
+        <int name="endOffset">17</int>
         <int name="origFreq">0</int>
         <arr name="suggestion">
           <lst>
-            <str name="word">maxtor</str>
-            <int name="freq">2</int>
-          </lst>
-          <lst>
-            <str name="word">motor</str>
+            <str name="word">ultrasharp</str>
             <int name="freq">1</int>
           </lst>
         </arr>
@@ -38,8 +34,14 @@
     </lst>
     <bool name="correctlySpelled">false</bool>
     <lst name="collations">
-      <str name="collation">dell maxtor</str>
-      <str name="collation">dell motor</str>
+      <lst name="collation">
+        <str name="collationQuery">dell ultrasharp</str>
+        <int name="hits">1</int>
+        <lst name="misspellingsAndCorrections">
+          <str name="delll">dell</str>
+          <str name="ultra sharp">ultrasharp</str>
+        </lst>
+      </lst>
     </lst>
   </lst>
 </response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -362,6 +362,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\partialResponseWithRangeFacetAndOther.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellCheckingExpandedCollationInCollations.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -593,6 +593,24 @@ namespace SolrNet.Tests
         }
 
         [Fact]
+        public void ParseSpellCheckingCollateTrueInExpandedCollations()
+        {
+            //Collations node now separates from collation nodes from suggestions
+            var parser = new SpellCheckResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellCheckingExpandedCollationInCollations.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.NotNull(spellChecking);
+            Assert.Equal("dell ultrasharp", spellChecking.Collation);
+            Assert.Equal(2, spellChecking.Count);
+            Assert.Equal(1, spellChecking.First().Suggestions.Count);
+            Assert.Equal("dell", spellChecking.First().Suggestions.First());
+            Assert.Equal(1, spellChecking.Last().Suggestions.Count);
+            Assert.Equal("ultrasharp", spellChecking.Last().Suggestions.First());
+            Assert.Equal(1, spellChecking.Collations.Count);
+        }
+
+        [Fact]
         public void ParseSpellCheckingCollateTrueInCollations()
         {
             //Collations node now separates from collation nodes from suggestions
@@ -601,9 +619,14 @@ namespace SolrNet.Tests
             var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
             var spellChecking = parser.ParseSpellChecking(docNode);
             Assert.NotNull(spellChecking);
-            Assert.Equal("dell ultrasharp", spellChecking.Collation);
+            Assert.Equal("dell maxtor", spellChecking.Collation);
             Assert.Equal(2, spellChecking.Count);
-            Assert.Equal(1, spellChecking.Collations.Count);
+            Assert.Equal(1, spellChecking.First().Suggestions.Count);
+            Assert.Equal("dell", spellChecking.First().Suggestions.First());
+            Assert.Equal(2, spellChecking.Last().Suggestions.Count);
+            Assert.Equal("maxtor", spellChecking.Last().Suggestions.First());
+            Assert.Equal("motor", spellChecking.Last().Suggestions.Last());
+            Assert.Equal(2, spellChecking.Collations.Count);
         }
 
         [Fact]

--- a/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using SolrNet.Utils;
+using System.Linq;
 
 namespace SolrNet.Impl.ResponseParsers
 {
@@ -63,6 +64,8 @@ namespace SolrNet.Impl.ResponseParsers
             {
                 // Solr 5.0+
                 collationNodes = collationsNode.XPathSelectElements("lst[@name='collation']");
+                if (collationNodes.Count() == 0)
+                    collationNodes = collationsNode.XPathSelectElements("str[@name='collation']");
             }
             else
             {
@@ -72,13 +75,17 @@ namespace SolrNet.Impl.ResponseParsers
 
             foreach (var cn in collationNodes)
             {
+                string collationValue = string.Empty;
                 if (cn.XPathSelectElement("str[@name='collationQuery']") != null)
+                    collationValue = cn.XPathSelectElement("str[@name='collationQuery']").Value;
+                else if (cn.Name.LocalName == "str")
+                    collationValue = cn.Value;
+
+                if (collationValue != string.Empty)
                 {
-                    r.Collations.Add(cn.XPathSelectElement("str[@name='collationQuery']").Value);
+                    r.Collations.Add(collationValue);
                     if (string.IsNullOrEmpty(r.Collation))
-                    {
-                        r.Collation = cn.XPathSelectElement("str[@name='collationQuery']").Value;
-                    }
+                        r.Collation = collationValue;
                 }
             }
 
@@ -94,7 +101,7 @@ namespace SolrNet.Impl.ResponseParsers
                     result.EndOffset = Convert.ToInt32(c.XPathSelectElement("int[@name='endOffset']").Value);
                     result.StartOffset = Convert.ToInt32(c.XPathSelectElement("int[@name='startOffset']").Value);
                     var suggestions = new List<string>();
-                    var suggestionNodes = c.XPathSelectElements("arr[@name='suggestion']/str");
+                    var suggestionNodes = c.XPathSelectElements("arr[@name='suggestion']/lst/str");
                     foreach (var suggestionNode in suggestionNodes)
                     {
                         suggestions.Add(suggestionNode.Value);


### PR DESCRIPTION
Collation results were not parsed correctly when collateExtendedResults
was set to false. There was also a problem with the parsing of suggestions.