### PR TITLE
Hotfix: Fix nuspec file for Windsor

### DIFF
--- a/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.nuspec
+++ b/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SolrNet.Windsor</id>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <title>SolrNet.Windsor</title>
     <authors>Mauricio Scheffer and contributors</authors>
     <owners>Mauricio Scheffer</owners>
@@ -11,7 +11,6 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Windsor facility for SolrNet</description>
     <language>en-US</language>
-
     <dependencies>
       <group targetFramework=".NETFramework4.6">
         <dependency id="SolrNet.Core" version="[0.9.1]" />
@@ -24,15 +23,11 @@
         <dependency id="Castle.Windsor" version="4.1.0" />
       </group>
     </dependencies>
-  
-    
   </metadata>
   <files>
-    <files>
-      <file src="bin\release\net46\Castle.Facilities.SolrNetIntegration.dll" target="lib\net46\Castle.Facilities.SolrNetIntegration.dll" />
-      <file src="bin\release\net46\Castle.Facilities.SolrNetIntegration.pdb" target="lib\net46\Castle.Facilities.SolrNetIntegration.pdb" />
-      <file src="bin\release\netstandard2.0\Castle.Facilities.SolrNetIntegration.dll" target="lib\netstandard2.0\Castle.Facilities.SolrNetIntegration.dll" />
-      <file src="bin\release\netstandard2.0\Castle.Facilities.SolrNetIntegration.pdb" target="lib\netstandard2.0\Castle.Facilities.SolrNetIntegration.pdb" />
-    </files>
+    <file src="bin\release\net46\Castle.Facilities.SolrNetIntegration.dll" target="lib\net46\Castle.Facilities.SolrNetIntegration.dll" />
+    <file src="bin\release\net46\Castle.Facilities.SolrNetIntegration.pdb" target="lib\net46\Castle.Facilities.SolrNetIntegration.pdb" />
+    <file src="bin\release\netstandard2.0\Castle.Facilities.SolrNetIntegration.dll" target="lib\netstandard2.0\Castle.Facilities.SolrNetIntegration.dll" />
+    <file src="bin\release\netstandard2.0\Castle.Facilities.SolrNetIntegration.pdb" target="lib\netstandard2.0\Castle.Facilities.SolrNetIntegration.pdb" />
   </files>
 </package>


### PR DESCRIPTION
The NuSpec file created an empty NuGet package.

Merging this to master as this should be a hotfix, and should be released asap.

Fixes #331 