### PR TITLE
Issue 108: Added support for atomic updates

### DIFF
--- a/SolrNet.Cloud.Tests/FakeOperations.cs
+++ b/SolrNet.Cloud.Tests/FakeOperations.cs
@@ -227,6 +227,36 @@ namespace SolrNet.Cloud.Tests
             return null;
         }
 
+        public ResponseHeader AtomicUpdate(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            SetLastOperation();
+            return null;
+        }
+
+        public ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            SetLastOperation();
+            return null;
+        }
+
+        public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            SetLastOperation();
+            return null;
+        }
+
+        public ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            SetLastOperation();
+            return null;
+        }
+
+        public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            SetLastOperation();
+            return null;
+        }
+
         public ResponseHeader BuildSpellCheckDictionary()
         {
             SetLastOperation();
@@ -464,6 +494,31 @@ namespace SolrNet.Cloud.Tests
         }
 
         public Task<ResponseHeader> DeleteAsync(IEnumerable<string> ids, ISolrQuery q)
+        {
+            SetLastOperation(); return null;
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            SetLastOperation(); return null;
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            SetLastOperation(); return null;
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            SetLastOperation(); return null;
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            SetLastOperation(); return null;
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
         {
             SetLastOperation(); return null;
         }

--- a/SolrNet.Cloud/SolrCloudBasicOperations.cs
+++ b/SolrNet.Cloud/SolrCloudBasicOperations.cs
@@ -88,6 +88,16 @@ namespace SolrNet.Cloud
             return PerformBasicOperation(operations => operations.SendAndParseExtract(cmd));
         }
 
+        public ResponseHeader AtomicUpdate(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            return PerformBasicOperation(operations => operations.AtomicUpdate(uniqueKey, id, updateSpecs, parameters));
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            return PerformBasicOperation(operations => operations.AtomicUpdateAsync(uniqueKey, id, updateSpecs, parameters));
+        }
+
         public Task<ResponseHeader> CommitAsync(CommitOptions options)
         {
             return PerformBasicOperation(operations => operations.CommitAsync(options));

--- a/SolrNet.Cloud/SolrCloudOperations.cs
+++ b/SolrNet.Cloud/SolrCloudOperations.cs
@@ -219,6 +219,26 @@ namespace SolrNet.Cloud
             return PerformOperation(operations => operations.EnumerateValidationResults());
         }
 
+        public ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            return PerformOperation(operations => operations.AtomicUpdate(doc, updateSpecs), true);
+        }
+
+        public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            return PerformOperation(operations => operations.AtomicUpdate(id, updateSpecs), true);
+        }
+
+        public ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            return PerformOperation(operations => operations.AtomicUpdate(doc, updateSpecs, parameters), true);
+        }
+
+        public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            return PerformOperation(operations => operations.AtomicUpdate(id, updateSpecs, parameters), true);
+        }
+
         public Task<ResponseHeader> CommitAsync()
             => PerformOperation(operations => operations.CommitAsync());
 
@@ -335,5 +355,17 @@ namespace SolrNet.Cloud
 
         public Task<SolrDIHStatus> GetDIHStatusAsync(KeyValuePair<string, string> options)
             => PerformOperation(operations => operations.GetDIHStatusAsync(options));
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+            => PerformOperation(operations => operations.AtomicUpdateAsync(doc, updateSpecs));
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+            => PerformOperation(operations => operations.AtomicUpdateAsync(id, updateSpecs));
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+            => PerformOperation(operations => operations.AtomicUpdateAsync(doc, updateSpecs, parameters));
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+            => PerformOperation(operations => operations.AtomicUpdateAsync(id, updateSpecs, parameters));
     }
 }

--- a/SolrNet.Tests.Common/Mocks/MSolrBasicOperations.cs
+++ b/SolrNet.Tests.Common/Mocks/MSolrBasicOperations.cs
@@ -86,6 +86,11 @@ namespace SolrNet.Tests.Mocks {
             throw new NotImplementedException();
         }
 
+        public Task<ResponseHeader> AtomicUpdateAsync(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<ResponseHeader> CommitAsync(CommitOptions options)
         {
             throw new NotImplementedException();

--- a/SolrNet.Tests.Common/Mocks/MSolrOperations.cs
+++ b/SolrNet.Tests.Common/Mocks/MSolrOperations.cs
@@ -315,6 +315,26 @@ namespace SolrNet.Tests.Mocks {
             throw new NotImplementedException();
         }
 
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<ResponseHeader> BuildSpellCheckDictionaryAsync()
         {
             throw new NotImplementedException();

--- a/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
+++ b/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
@@ -60,8 +60,8 @@
     <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
-    <Reference Include="ZooKeeperNetEx, Version=3.4.9.4, Culture=neutral, PublicKeyToken=42cd15de36f9b993, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeperNetEx.3.4.9.4\lib\net45\ZooKeeperNetEx.dll</HintPath>
+    <Reference Include="ZooKeeperNetEx">
+      <HintPath>..\packages\ZooKeeperNetEx.3.4.10.1\lib\net45\ZooKeeperNetEx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SolrNet.Tests/AtomicUpdateCommandTests.cs
+++ b/SolrNet.Tests/AtomicUpdateCommandTests.cs
@@ -15,119 +15,272 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using Xunit;
-using Moroco;
-using SolrNet.Attributes;
 using SolrNet.Commands;
-using SolrNet.Impl;
-using SolrNet.Impl.FieldSerializers;
-using SolrNet.Mapping;
-using SolrNet.Tests.Utils;
+using Moroco;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
-namespace SolrNet.Tests {
-	public class AtomicUpdateCommandTests {
+namespace SolrNet.Tests
+{
+    public class AtomicUpdateCommandTests {
 		[Fact]
 		public void AtomicUpdateSet() {
 		    var conn = new Mocks.MSolrConnection();
-		    conn.post += (url, content) => {
-		        Assert.Equal("/update", url);
-		        Assert.Equal("<add overwrite=\"true\"><doc><field name=\"id\">0</field><field name=\"animal\" update=\"set\">squirrel</field></doc></add>", content);
-		        Console.WriteLine(content);
-		        return null;
-		    };
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+		        Assert.Equal("[{\"id\":\"0\",\"animal\":{\"set\":\"squirrel\"}}]", text);
+		        Console.WriteLine(text);
+                return null;
+		    });
             var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("animal", AtomicUpdateType.Set, "squirrel") };
             var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
             cmd.Execute(conn);
-            Assert.Equal(1, conn.post.Calls);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        public void AtomicUpdateSetArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"animal\":{\"set\":[\"squirrel\",\"fox\"]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("animal", AtomicUpdateType.Set, new string[] {"squirrel", "fox"}) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        public void AtomicUpdateSetEmptyArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"animal\":{\"set\":[]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("animal", AtomicUpdateType.Set, new string[] {}) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
         }
 
         [Fact]
         public void AtomicUpdateAdd()
         {
             var conn = new Mocks.MSolrConnection();
-            conn.post += (url, content) => {
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
                 Assert.Equal("/update", url);
-                Assert.Equal("<add overwrite=\"true\"><doc><field name=\"id\">0</field><field name=\"food\" update=\"add\">nuts</field></doc></add>", content);
-                Console.WriteLine(content);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"add\":\"nuts\"}}]", text);
+                Console.WriteLine(text);
                 return null;
-            };
+            });
             var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Add, "nuts") };
             var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
             cmd.Execute(conn);
-            Assert.Equal(1, conn.post.Calls);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateAddArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"add\":[\"nuts\",\"seeds\",\"berries\"]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Add, new string[] { "nuts", "seeds", "berries" }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateAddEmptyArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"add\":[]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Add, new string[] { }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemove()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"remove\":\"nuts\"}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Remove, "nuts") };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemoveArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"remove\":[\"nuts\",\"seeds\",\"berries\"]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Remove, new string[] { "nuts", "seeds", "berries" }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemoveEmptyArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"remove\":[]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Remove, new string[] { }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemoveRegex()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"removeregex\":\"nu.*\"}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.RemoveRegex, "nu.*") };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemoveRegexArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"removeregex\":[\"nu.*\",\"seeds\",\"berr.+\"]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.RemoveRegex, new string[] { "nu.*", "seeds", "berr.+" }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateRemoveRegexEmptyArray()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"removeregex\":[]}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.RemoveRegex, new string[] { }) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
         }
 
         [Fact]
         public void AtomicUpdateInc()
         {
             var conn = new Mocks.MSolrConnection();
-            conn.post += (url, content) => {
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
                 Assert.Equal("/update", url);
-                Assert.Equal("<add overwrite=\"true\"><doc><field name=\"id\">0</field><field name=\"count\" update=\"inc\">3</field></doc></add>", content);
-                Console.WriteLine(content);
+                Assert.Equal("[{\"id\":\"0\",\"count\":{\"inc\":3}}]", text);
+                Console.WriteLine(text);
                 return null;
-            };
-            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, "3") };
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, 3) };
             var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
             cmd.Execute(conn);
-            Assert.Equal(1, conn.post.Calls);
-        }
-
-        [Fact]
-        public void AtomicUpdateNull()
-        {
-            var conn = new Mocks.MSolrConnection();
-            conn.post += (url, content) => {
-                Assert.Equal("/update", url);
-                Assert.Equal("<add overwrite=\"true\"><doc><field name=\"id\">0</field><field name=\"animal\" null=\"true\" /></doc></add>", content);
-                Console.WriteLine(content);
-                return null;
-            };
-            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("animal", AtomicUpdateType.Inc, null) };
-            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
-            cmd.Execute(conn);
-            Assert.Equal(1, conn.post.Calls);
+            Assert.Equal(1, conn.postStream.Calls);
         }
 
         [Fact]
         public void AtomicUpdateWithParameter()
         {
             var conn = new Mocks.MSolrConnection();
-            conn.post += (url, content) => {
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
                 Assert.Equal("/update", url);
-                Assert.Equal("<add commitWithin=\"4343\" overwrite=\"true\"><doc><field name=\"id\">0</field><field name=\"count\" update=\"inc\">3</field></doc></add>", content);
-                Console.WriteLine(content);
+                Assert.Equal("commitwithin", ((KeyValuePair<string, string>[])param)[0].Key);
+                Assert.Equal("4343", ((KeyValuePair<string, string>[]) param)[0].Value);
+                Assert.Equal("[{\"id\":\"0\",\"count\":{\"inc\":3}}]", text);
+                Console.WriteLine(text);
                 return null;
-            };
+            });
             var parameters = new AtomicUpdateParameters { CommitWithin = 4343 };
-            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, "3") };
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, 3) };
             var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, parameters);
             cmd.Execute(conn);
-            Assert.Equal(1, conn.post.Calls);
+            Assert.Equal(1, conn.postStream.Calls);
         }
 
         [Fact]
         public void AtomicUpdateNullUniqueKeyHandledGracefully()
         {
             var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, "3") };
-            var cmd = new AtomicUpdateCommand(null, "0", updateSpecs, null);
-            Assert.Throws<ArgumentNullException>(() => cmd.Execute(new Mocks.MSolrConnection()));
+            Assert.Throws<ArgumentNullException>(() => new AtomicUpdateCommand(null, "0", updateSpecs, null));
         }
 
         [Fact]
         public void AtomicUpdateNullIdHandledGracefully()
         {
             var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, "3") };
-            var cmd = new AtomicUpdateCommand("id", null, updateSpecs, null);
-            Assert.Throws<ArgumentNullException>(() => cmd.Execute(new Mocks.MSolrConnection()));
+            Assert.Throws<ArgumentNullException>(() => new AtomicUpdateCommand("id", null, updateSpecs, null));
         }
 
         [Fact]
         public void AtomicUpdateNullSpecHandledGracefully()
         {
-            var cmd = new AtomicUpdateCommand("id", "0", null, null);
-            Assert.Throws<NullReferenceException>(() => cmd.Execute(new Mocks.MSolrConnection()));
+            Assert.Throws<ArgumentNullException>(() => new AtomicUpdateCommand("id", "0", null, null));
         }
     }
 }

--- a/SolrNet/AtomicUpdateSpec.cs
+++ b/SolrNet/AtomicUpdateSpec.cs
@@ -46,17 +46,17 @@ namespace SolrNet
         /// <summary>
         /// Name of the field to apply the update to
         /// </summary>
-        public string Field;
+        public string Field { get; set; }
 
         /// <summary>
         /// Type of update to apply
         /// </summary>
-        public AtomicUpdateType Type;
+        public AtomicUpdateType Type { get; set; }
 
         /// <summary>
         /// The update value
         /// </summary>
-        public string Value;
+        public string Value { get; set; }
 
         public AtomicUpdateSpec(string field, AtomicUpdateType type, string value)
         {

--- a/SolrNet/AtomicUpdateSpec.cs
+++ b/SolrNet/AtomicUpdateSpec.cs
@@ -22,21 +22,29 @@ namespace SolrNet
     public enum AtomicUpdateType
     {
         /// <summary>
-        /// Sets or replaces a particular value, or remove the value if null is specified as the new value
+        /// Sets or replaces the value(s) of a particular field
         /// </summary>
         Set,
         /// <summary>
-        /// Adds an additional value to a multi-valued field
+        /// Adds additional value(s) to a multi-valued field
         /// </summary>
         Add,
         /// <summary>
         /// Increments a numeric value by a specific amount
         /// </summary>
-        Inc
+        Inc,
+        /// <summary>
+        /// Removes specified value(s) from a multi-valued field
+        /// </summary>
+        Remove,
+        /// <summary>
+        /// Removes value(s) from a multi-valued field according to the regular expression(s) specified
+        /// </summary>
+        RemoveRegex
     }
 
     /// <summary>
-    /// Contains all the information to make a single atomic update to a indexed document.
+    /// Contains all the information to make a single atomic update to an indexed document.
     /// </summary>
     /// <remarks>
     /// See https://wiki.apache.org/solr/Atomic_Updates
@@ -46,19 +54,51 @@ namespace SolrNet
         /// <summary>
         /// Name of the field to apply the update to
         /// </summary>
-        public string Field { get; set; }
+        public string Field { get; private set; }
 
         /// <summary>
         /// Type of update to apply
         /// </summary>
-        public AtomicUpdateType Type { get; set; }
+        public AtomicUpdateType Type { get; private set; }
 
         /// <summary>
         /// The update value
         /// </summary>
-        public string Value { get; set; }
+        public object Value { get; private set; }
 
+        /// <summary>
+        /// Constructor for single string updates
+        /// </summary>
+        /// <param name="field">Name of the field to apply the update to</param>
+        /// <param name="type">Type of update to apply</param>
+        /// <param name="value">String containing the update</param>
         public AtomicUpdateSpec(string field, AtomicUpdateType type, string value)
+        {
+            Field = field;
+            Type = type;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Constructor for multiple string updates
+        /// </summary>
+        /// <param name="field">Name of the field to apply the update to</param>
+        /// <param name="type">Type of update to apply</param>
+        /// <param name="value">String array containing the updates</param>
+        public AtomicUpdateSpec(string field, AtomicUpdateType type, string[] value)
+        {
+            Field = field;
+            Type = type;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Constructor for int updates
+        /// </summary>
+        /// <param name="field">Name of the field to apply the update to</param>
+        /// <param name="type">Type of update to apply</param>
+        /// <param name="value">Int containing the update</param>
+        public AtomicUpdateSpec(string field, AtomicUpdateType type, int value)
         {
             Field = field;
             Type = type;

--- a/SolrNet/ISolrBasicOperations.cs
+++ b/SolrNet/ISolrBasicOperations.cs
@@ -151,5 +151,15 @@ namespace SolrNet {
         /// <param name="parameters">The atomic update parameters</param>
         /// <returns></returns>
         ResponseHeader AtomicUpdate(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
+        
+        /// <summary>
+        /// Updates the document with the provided ID (asynchronous)
+        /// </summary>
+        /// <param name="uniqueKey">Name of the unique key field</param>
+        /// <param name="id">ID of the document to update</param>
+        /// <param name="updateSpecs">Specifications for the updates</param>
+        /// <param name="parameters">The atomic update parameters</param>
+        /// <returns></returns>
+        Task<ResponseHeader> AtomicUpdateAsync(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
     }
 }

--- a/SolrNet/ISolrOperations.cs
+++ b/SolrNet/ISolrOperations.cs
@@ -458,7 +458,15 @@ namespace SolrNet
         /// <param name="updateSpecs">The specification that defines the update</param>
         /// <returns></returns>
         ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs);
- 
+
+        /// <summary>
+        /// Updates a document according to the supplied specification (asynchronous).
+        /// </summary>
+        /// <param name="doc">The document to update</param>
+        /// <param name="updateSpecs">The specification that defines the update</param>
+        /// <returns></returns>
+        Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs);
+
         /// <summary>
         /// Updates the document with the supplied ID according to the supplied specification.
         /// </summary>
@@ -466,7 +474,15 @@ namespace SolrNet
         /// <param name="updateSpecs">The specification that defines the update</param>
         /// <returns></returns>
         ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs);
- 
+
+        /// <summary>
+        /// Updates the document with the supplied ID according to the supplied specification (asynchronous).
+        /// </summary>
+        /// <param name="id">The ID of the document to update</param>
+        /// <param name="updateSpecs">The specification that defines the update</param>
+        /// <returns></returns>
+        Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs);
+
         /// <summary>
         /// Updates a document according to the supplied specification.
         /// </summary>
@@ -475,7 +491,16 @@ namespace SolrNet
         /// <param name="parameters">The atomic update parameters</param>
         /// <returns></returns>
         ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
- 
+
+        /// <summary>
+        /// Updates a document according to the supplied specification (asynchronous).
+        /// </summary>
+        /// <param name="doc">The document to update</param>
+        /// <param name="updateSpecs">The specification that defines the update</param>
+        /// <param name="parameters">The atomic update parameters</param>
+        /// <returns></returns>
+        Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
+
         /// <summary>
         /// Updates the document with the supplied ID according to the supplied specification.
         /// </summary>
@@ -484,5 +509,14 @@ namespace SolrNet
         /// <param name="parameters">The atomic update parameters</param>
         /// <returns></returns>
         ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
+
+        /// <summary>
+        /// Updates the document with the supplied ID according to the supplied specification (asynchronous).
+        /// </summary>
+        /// <param name="id">The ID of the document to update</param>
+        /// <param name="updateSpecs">The specification that defines the update</param>
+        /// <param name="parameters">The atomic update parameters</param>
+        /// <returns></returns>
+        Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters);
     }
 }

--- a/SolrNet/Impl/SolrBasicServer.cs
+++ b/SolrNet/Impl/SolrBasicServer.cs
@@ -49,7 +49,6 @@ namespace SolrNet.Impl {
             this.dihStatusParser = dihStatusParser;
         }
 
-
         public ResponseHeader Commit(CommitOptions options)
         {
             CommitCommand cmd = GetCommitCommand(options);
@@ -117,9 +116,6 @@ namespace SolrNet.Impl {
             return queryExecuter.Execute(query, options);
         }
 
-     
-   
-
         public ExtractResponse SendAndParseExtract(ISolrCommand cmd)
         {
             var r = Send(cmd);
@@ -135,6 +131,16 @@ namespace SolrNet.Impl {
             return extractResponseParser.Parse(xml);
         }
 
+        public ResponseHeader AtomicUpdate(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters){
+            var atomicUpdate = new AtomicUpdateCommand(uniqueKey, id, updateSpecs, parameters);
+            return SendAndParseHeader(atomicUpdate);
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string uniqueKey, string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            var atomicUpdate = new AtomicUpdateCommand(uniqueKey, id, updateSpecs, parameters);
+            return SendAndParseHeaderAsync(atomicUpdate);
+        }
 
         public ResponseHeader Ping() {
             return SendAndParseHeader(new PingCommand());

--- a/SolrNet/Impl/SolrServer.cs
+++ b/SolrNet/Impl/SolrServer.cs
@@ -340,23 +340,47 @@ namespace SolrNet.Impl
             string uniqueKey = mappingManager.GetUniqueKey(doc.GetType()).FieldName;
             return basicServer.AtomicUpdate(uniqueKey, GetId(doc).ToString(), updateSpecs, null);
         }
- 
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            string uniqueKey = mappingManager.GetUniqueKey(doc.GetType()).FieldName;
+            return basicServer.AtomicUpdateAsync(uniqueKey, GetId(doc).ToString(), updateSpecs, null);
+        }
+
         public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
         {
             string uniqueKey = mappingManager.GetUniqueKey(typeof(T)).FieldName;
             return basicServer.AtomicUpdate(uniqueKey, id, updateSpecs, null);
         }
- 
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs)
+        {
+            string uniqueKey = mappingManager.GetUniqueKey(typeof(T)).FieldName;
+            return basicServer.AtomicUpdateAsync(uniqueKey, id, updateSpecs, null);
+        }
+
         public ResponseHeader AtomicUpdate(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
         {
             string uniqueKey = mappingManager.GetUniqueKey(doc.GetType()).FieldName;
             return basicServer.AtomicUpdate(uniqueKey, GetId(doc).ToString(), updateSpecs, parameters);
         }
- 
+
+        public Task<ResponseHeader> AtomicUpdateAsync(T doc, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            string uniqueKey = mappingManager.GetUniqueKey(doc.GetType()).FieldName;
+            return basicServer.AtomicUpdateAsync(uniqueKey, GetId(doc).ToString(), updateSpecs, parameters);
+        }
+
         public ResponseHeader AtomicUpdate(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
         {
             string uniqueKey = mappingManager.GetUniqueKey(typeof(T)).FieldName;
             return basicServer.AtomicUpdate(uniqueKey, id, updateSpecs, parameters);
+        }
+
+        public Task<ResponseHeader> AtomicUpdateAsync(string id, IEnumerable<AtomicUpdateSpec> updateSpecs, AtomicUpdateParameters parameters)
+        {
+            string uniqueKey = mappingManager.GetUniqueKey(typeof(T)).FieldName;
+            return basicServer.AtomicUpdateAsync(uniqueKey, id, updateSpecs, parameters);
         }
 
         public Task<SolrQueryResults<T>> QueryAsync(string q) => QueryAsync(new SolrQuery(q));


### PR DESCRIPTION
Xavier/gjunge,

I have completed my work on the atomic updates feature (original details here https://github.com/SolrNet/SolrNet/pull/339).

A couple of points to note:

1. The web requests are implemented using json. This is different to how the other commands have been implemented (xml). The reason for this is that the solr documentation for atomic updates is very limited and no examples exist using xml. Unfortunately, I didn't have time to reverse engineer the mechanism. As solr supports both, I don't think this should be an issue, but it felt necessary to explain the inconsistency.

2. The integration test will not work with the version of solr which forms part of the solrNet distribution. This version is very old and does not support the full set of atomic update modifiers. I have ran the test against solr 7.1.0 and it passes. It might be an idea to think about updating the version of solr within the distribution. Does anyone know which version of solr we are actually targeting at present?

Many thanks!