### PR TITLE
Extending collations support

### DIFF
--- a/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsNoExtendedSolr4-.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsNoExtendedSolr4-.xml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="spellcheck">
+    <lst name="suggestions">
+      <lst name="aodit">
+        <int name="numFound">5</int>
+        <int name="startOffset">0</int>
+        <int name="endOffset">5</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>aod it</str>
+          <str>addit</str>
+          <str>ao dit</str>
+          <str>adoit</str>
+        </arr>
+      </lst>
+      <lst name="collation">
+        <int name="numFound">4</int>
+        <int name="startOffset">6</int>
+        <int name="endOffset">15</int>
+        <arr name="suggestion">
+          <str>colla tion</str>
+          <str>cellation</str>
+          <str>coll ation</str>
+          <str>collection</str>
+        </arr>
+      </lst>
+      <str name="collation">audit collation</str>
+      <str name="collation">audit (colla tion)</str>
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsNoExtendedSolr5+.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsNoExtendedSolr5+.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="spellcheck">
+    <lst name="suggestions">
+      <lst name="audot">
+        <int name="numFound">5</int>
+        <int name="startOffset">0</int>
+        <int name="endOffset">5</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>au dot</str>
+          <str>audet</str>
+          <str>aud ot</str>
+          <str>audyt</str>
+        </arr>
+      </lst>
+      <lst name="collation">
+        <int name="numFound">4</int>
+        <int name="startOffset">6</int>
+        <int name="endOffset">15</int>
+        <arr name="suggestion">
+          <str>colla tion</str>
+          <str>collection</str>
+          <str>coll ation</str>
+          <str>collusion</str>
+        </arr>
+      </lst>
+    </lst>
+    <lst name="collations">
+      <str name="collation">audit collation</str>
+      <str name="collation">audit (colla tion)</str>
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -349,6 +349,12 @@
     <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsSolr4-.xml" />
     <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsSolr5+.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsNoExtendedSolr4-.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsNoExtendedSolr5+.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/SolrNet/Impl/CollationResult.cs
+++ b/SolrNet/Impl/CollationResult.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 namespace SolrNet.Impl {
@@ -21,19 +22,48 @@ namespace SolrNet.Impl {
     /// Collation Result
     /// </summary>
     public class CollationResult {
-        /// <summary>
-        /// Collation query term
-        /// </summary>
-        public string CollationQuery { get; set;}
 
         /// <summary>
         /// Number of hits
         /// </summary>
-        public long Hits { get; set;}
+        private long _hits;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal CollationResult()
+        {
+            MisspellingsAndCorrections = new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Collation query term
+        /// </summary>
+        public string CollationQuery { get; internal set;}
+
+        /// <summary>
+        /// Number of hits
+        /// </summary>
+        public long Hits {
+            get {
+                if (_hits >= 0)
+                {
+                    return _hits;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Operation not supported when collateExtendedResults parameter is set to false.");
+                }
+            }
+            internal set
+            {
+                _hits = value;
+            }
+        }
 
         /// <summary>
         /// MisspellingsAndCorrections
         /// </summary>
-        public IDictionary<string, string> MisspellingsAndCorrections { get; set;}
+        public IDictionary<string, string> MisspellingsAndCorrections { get; internal set;}
     }
 }


### PR DESCRIPTION
Adding support when spellcheck.collateExtendedResults is set to false (true by default).
This commit fixes the issue described in https://github.com/SolrNet/SolrNet/issues/310.