### PR TITLE
Support for PostSolrConnections in SolrNet.Windsor

### DIFF
--- a/Castle.Facilities.SolrNetIntegration/SolrCore.cs
+++ b/Castle.Facilities.SolrNetIntegration/SolrCore.cs
@@ -25,6 +25,7 @@ namespace Castle.Facilities.SolrNetIntegration {
         public string Id { get; private set; }
         public Type DocumentType { get; private set; }
         public string Url { get; private set; }
+        public bool PostConnection { get; private set; }
 
         /// <summary>
         /// Creates a new Solr core for configuration
@@ -32,10 +33,11 @@ namespace Castle.Facilities.SolrNetIntegration {
         /// <param name="id">Component name for <see cref="ISolrOperations{T}"/></param>
         /// <param name="documentType">Document type</param>
         /// <param name="url">Core url</param>
-        public SolrCore(string id, Type documentType, string url) {
+        public SolrCore(string id, Type documentType, string url, bool postConnection = false) {
             Id = id;
             DocumentType = documentType;
             Url = url;
+            PostConnection = postConnection;
         }
 
         /// <summary>
@@ -43,6 +45,6 @@ namespace Castle.Facilities.SolrNetIntegration {
         /// </summary>
         /// <param name="documentType">Document type</param>
         /// <param name="url">Core url</param>
-        public SolrCore(Type documentType, string url) : this(Guid.NewGuid().ToString(), documentType, url) { }
+        public SolrCore(Type documentType, string url, bool postConnection = false) : this(Guid.NewGuid().ToString(), documentType, url, postConnection) { }
     }
 }

--- a/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
+++ b/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
@@ -152,9 +152,14 @@ namespace Castle.Facilities.SolrNetIntegration
         private void RegisterCore(SolrCore core)
         {
             var coreConnectionId = core.Id + typeof(SolrConnection);
-            Kernel.Register(Component.For<ISolrConnection>().ImplementedBy<SolrConnection>()
+            if (core.PostConnection)
+              Kernel.Register(Component.For<ISolrConnection>().ImplementedBy<PostSolrConnection>()
                                 .Named(coreConnectionId)
                                 .Parameters(Parameter.ForKey("serverURL").Eq(core.Url)));
+            else
+              Kernel.Register(Component.For<ISolrConnection>().ImplementedBy<SolrConnection>()
+                                  .Named(coreConnectionId)
+                                  .Parameters(Parameter.ForKey("serverURL").Eq(core.Url)));
 
             var ISolrQueryExecuter = typeof(ISolrQueryExecuter<>).MakeGenericType(core.DocumentType);
             var SolrQueryExecuter = typeof(SolrQueryExecuter<>).MakeGenericType(core.DocumentType);
@@ -183,9 +188,9 @@ namespace Castle.Facilities.SolrNetIntegration
         /// </summary>
         /// <param name="documentType"></param>
         /// <param name="coreUrl"></param>
-        public void AddCore(Type documentType, string coreUrl)
+        public void AddCore(Type documentType, string coreUrl, bool postConnection = false)
         {
-            AddCore(Guid.NewGuid().ToString(), documentType, coreUrl);
+            AddCore(Guid.NewGuid().ToString(), documentType, coreUrl, postConnection);
         }
 
         /// <summary>
@@ -194,10 +199,11 @@ namespace Castle.Facilities.SolrNetIntegration
         /// <param name="coreId">Component name for <see cref="ISolrOperations{T}"/></param>
         /// <param name="documentType"></param>
         /// <param name="coreUrl"></param>
-        public void AddCore(string coreId, Type documentType, string coreUrl)
+        /// <param name="postConnection"></param>
+        public void AddCore(string coreId, Type documentType, string coreUrl, bool postConnection = false)
         {
             ValidateUrl(coreUrl);
-            cores.Add(new SolrCore(coreId, documentType, coreUrl));
+            cores.Add(new SolrCore(coreId, documentType, coreUrl, postConnection));
         }
 
         private void AddCoresFromConfig()

--- a/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
+++ b/Castle.Facilities.SolrNetIntegration/SolrNetFacility.cs
@@ -153,9 +153,11 @@ namespace Castle.Facilities.SolrNetIntegration
         {
             var coreConnectionId = core.Id + typeof(SolrConnection);
             if (core.PostConnection)
-              Kernel.Register(Component.For<ISolrConnection>().ImplementedBy<PostSolrConnection>()
-                                .Named(coreConnectionId)
-                                .Parameters(Parameter.ForKey("serverURL").Eq(core.Url)));
+              Kernel.Register(
+                Component.For<ISolrConnection>().ImplementedBy<PostSolrConnection>()
+                         .Named(coreConnectionId)
+                         .DependsOn(Dependency.OnValue("serverURL", core.Url))
+              );
             else
               Kernel.Register(Component.For<ISolrConnection>().ImplementedBy<SolrConnection>()
                                   .Named(coreConnectionId)

--- a/SolrNet/Impl/SolrPostConnection.cs
+++ b/SolrNet/Impl/SolrPostConnection.cs
@@ -15,19 +15,19 @@ namespace SolrNet.Impl
 	/// </summary>
 	public class PostSolrConnection : ISolrConnection
 	{
-		private readonly ISolrConnection conn;
-		private readonly string serverUrl;
+		    private readonly ISolrConnection conn;
+		    private readonly string serverUrl;
 
-		public PostSolrConnection(ISolrConnection conn, string serverUrl)
-		{
-			this.conn = conn;
-			this.serverUrl = serverUrl;
-		}
+		    public PostSolrConnection(ISolrConnection conn, string serverUrl)
+		    {
+			    this.conn = conn;
+			    this.serverUrl = serverUrl;
+		    }
 
-		public string Post(string relativeUrl, string s)
-		{
-			return conn.Post(relativeUrl, s);
-		}
+		    public string Post(string relativeUrl, string s)
+		    {
+			    return conn.Post(relativeUrl, s);
+		    }
 
         public Task<string> PostAsync(string relativeUrl, string s)
         {
@@ -41,9 +41,16 @@ namespace SolrNet.Impl
             var request = (HttpWebRequest)WebRequest.Create(u.Uri);
             request.Method = "POST";
             request.ContentType = "application/x-www-form-urlencoded";
-            var qs = string.Join("&", parameters
+
+          var param = new List<KeyValuePair<string, string>>();
+          if (parameters != null)
+            param.AddRange(parameters);
+
+          param.Add(KV.Create("wt", "xml"));
+          var qs = string.Join("&", param
                 .Select(kv => string.Format("{0}={1}", HttpUtility.UrlEncode(kv.Key), HttpUtility.UrlEncode(kv.Value)))
                 .ToArray());
+
             request.ContentLength = Encoding.UTF8.GetByteCount(qs);
             request.ProtocolVersion = HttpVersion.Version11;
             request.KeepAlive = true;
@@ -52,23 +59,23 @@ namespace SolrNet.Impl
         }
 
         public string Get(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters)
-		{
-            var g = PrepareGet(relativeUrl, parameters);
-			try
-			{
-				using (var postParams = g.request.GetRequestStream())
-				using (var sw = new StreamWriter(postParams))
-					sw.Write(g.queryString);
-				using (var response = g.request.GetResponse())
-				using (var responseStream = response.GetResponseStream())
-				using (var sr = new StreamReader(responseStream, Encoding.UTF8, true))
-					return sr.ReadToEnd();
-			}
-			catch (WebException e)
-			{
-				throw new SolrConnectionException(e);
-			}
-		}
+		    {
+          var g = PrepareGet(relativeUrl, parameters);
+			    try
+			    {
+				    using (var postParams = g.request.GetRequestStream())
+				    using (var sw = new StreamWriter(postParams))
+					    sw.Write(g.queryString);
+				    using (var response = g.request.GetResponse())
+				    using (var responseStream = response.GetResponseStream())
+				    using (var sr = new StreamReader(responseStream, Encoding.UTF8, true))
+					    return sr.ReadToEnd();
+			    }
+			    catch (WebException e)
+			    {
+				    throw new SolrConnectionException(e);
+			    }
+		    }
 
         public async Task<string> GetAsync(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters)
         {

--- a/SolrNet/Impl/SolrPostConnection.cs
+++ b/SolrNet/Impl/SolrPostConnection.cs
@@ -24,7 +24,9 @@ namespace SolrNet.Impl
 			    this.serverUrl = serverUrl;
 		    }
 
-		    public string Post(string relativeUrl, string s)
+	      public string ServerUrl => serverUrl;
+
+	      public string Post(string relativeUrl, string s)
 		    {
 			    return conn.Post(relativeUrl, s);
 		    }


### PR DESCRIPTION
Allowing Multicore support for Post Connections
Also changed Post Connection to pass in XML as the parameter so SolrNet can parse correctly (was getting errors because later Solr versions return JSON by default instead of XML.