### PR TITLE
Collations issue fix

### DIFF
--- a/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsDuplicatesSolr4-.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsDuplicatesSolr4-.xml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="spellcheck">
+    <lst name="suggestions">
+      <lst name="aodit">
+        <int name="numFound">2</int>
+        <int name="startOffset">0</int>
+        <int name="endOffset">5</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>aod it</str>         
+        </arr>
+      </lst>
+      <lst name="aodit">
+        <int name="numFound">2</int>
+        <int name="startOffset">6</int>
+        <int name="endOffset">17</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>aod it</str>
+        </arr>
+      </lst>
+      <lst name="collation">
+        <str name="collationQuery">audit audit</str>
+        <int name="hits">1111</int>
+        <lst name="misspellingsAndCorrections">
+          <str name="aodit">audit</str>
+          <str name="aodit">audit</str>
+        </lst>
+      </lst>
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsDuplicatesSolr5+.xml
+++ b/SolrNet.Tests/Resources/responseWithSpellCheckingAndCollationsDuplicatesSolr5+.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <result numFound="1" start="0">
+    <doc>
+      <str name="Key">224fbdc1-12df-4520-9fbe-dd91f916eba1</str>
+    </doc>
+  </result>
+  <lst name="spellcheck">
+    <lst name="suggestions">
+      <lst name="aodit">
+        <int name="numFound">2</int>
+        <int name="startOffset">0</int>
+        <int name="endOffset">5</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>ao dit</str>          
+        </arr>
+      </lst>
+      <lst name="aodit">
+        <int name="numFound">2</int>
+        <int name="startOffset">6</int>
+        <int name="endOffset">17</int>
+        <arr name="suggestion">
+          <str>audit</str>
+          <str>ao dit</str>          
+        </arr>
+      </lst>
+    </lst>
+    <lst name="collations">
+      <lst name="collation">
+        <str name="collationQuery">audit audit</str>
+        <long name="hits">1111</long>
+        <lst name="misspellingsAndCorrections">
+          <str name="aodit">audit</str>
+          <str name="aodit">audit</str>
+        </lst>
+      </lst>          
+    </lst>
+  </lst>
+</response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -361,6 +361,12 @@
     <EmbeddedResource Include="Resources\solrManagedSchemaEmptyUniqueKey.xml" />
     <EmbeddedResource Include="Resources\solrManagedSchemaNoUniqueKey.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsDuplicatesSolr5+.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithSpellCheckingAndCollationsDuplicatesSolr4-.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -680,6 +680,37 @@ namespace SolrNet.Tests
             Assert.Equal("Operation not supported when collateExtendedResults parameter is set to false.", ex2.Message);            
         }
 
+        [Theory]
+        [InlineData("4-")]
+        [InlineData("5+")]
+        public void ParseSpellCheckingCollationsDuplicates(string solrVersion)
+        {
+            //Collations node now separates from collation nodes from suggestions
+            var parser = new SpellCheckResponseParser<Product>();
+            XDocument xml;
+
+            if (solrVersion.Equals("5+"))
+            {
+                xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellCheckingAndCollationsDuplicatesSolr5+.xml");
+            }
+            else
+            {
+                xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellCheckingAndCollationsDuplicatesSolr4-.xml");
+            }
+
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.NotNull(spellChecking);
+            Assert.NotNull(spellChecking.Collations);
+            Assert.Equal(1, spellChecking.Collations.Count);
+            //First result
+            Assert.Equal("audit audit", spellChecking.Collations.ElementAt(0).CollationQuery);
+            Assert.Equal(1111, spellChecking.Collations.ElementAt(0).Hits);
+            Assert.Equal(2, spellChecking.Collations.ElementAt(0).MisspellingsAndCorrections.Count);
+            Assert.Equal("audit", spellChecking.Collations.ElementAt(0).MisspellingsAndCorrections.ElementAt(0).Value);
+            Assert.Equal("audit", spellChecking.Collations.ElementAt(0).MisspellingsAndCorrections.ElementAt(1).Value);                     
+        }
+
         [Fact]
         public void ParseClustering()
         {

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -634,14 +634,14 @@ namespace SolrNet.Tests
             Assert.Equal("audit differences", spellChecking.Collations.First().CollationQuery);
             Assert.Equal(1111, spellChecking.Collations.First().Hits);
             Assert.Equal(2, spellChecking.Collations.First().MisspellingsAndCorrections.Count);
-            Assert.Equal("audit", spellChecking.Collations.First().MisspellingsAndCorrections["aodit"]);
-            Assert.Equal("differences", spellChecking.Collations.First().MisspellingsAndCorrections["differencex"]);
+            Assert.Equal("audit", spellChecking.Collations.First().MisspellingsAndCorrections.Where(mc => mc.Key == "aodit").First().Value);
+            Assert.Equal("differences", spellChecking.Collations.First().MisspellingsAndCorrections.Where(mc => mc.Key == "differencex").First().Value);
             //Second result
             Assert.Equal("(ao dit) differences", spellChecking.Collations.Last().CollationQuery);
             Assert.Equal(1234, spellChecking.Collations.Last().Hits);
             Assert.Equal(2, spellChecking.Collations.Last().MisspellingsAndCorrections.Count);
-            Assert.Equal("ao dit", spellChecking.Collations.Last().MisspellingsAndCorrections["aodit"]);
-            Assert.Equal("differences", spellChecking.Collations.Last().MisspellingsAndCorrections["differencex"]);
+            Assert.Equal("ao dit", spellChecking.Collations.Last().MisspellingsAndCorrections.Where(mc => mc.Key == "aodit").First().Value);
+            Assert.Equal("differences", spellChecking.Collations.Last().MisspellingsAndCorrections.Where(mc => mc.Key == "differencex").First().Value);
         }
 
         [Theory]

--- a/SolrNet/Impl/CollationResult.cs
+++ b/SolrNet/Impl/CollationResult.cs
@@ -33,7 +33,7 @@ namespace SolrNet.Impl {
         /// </summary>
         internal CollationResult()
         {
-            MisspellingsAndCorrections = new Dictionary<string, string>();
+            MisspellingsAndCorrections = new List<KeyValuePair<string, string>>();
         }
 
         /// <summary>
@@ -64,6 +64,6 @@ namespace SolrNet.Impl {
         /// <summary>
         /// MisspellingsAndCorrections
         /// </summary>
-        public IDictionary<string, string> MisspellingsAndCorrections { get; internal set;}
+        public ICollection<KeyValuePair<string, string>> MisspellingsAndCorrections { get; internal set;}
     }
 }

--- a/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/SpellCheckResponseParser.cs
@@ -89,7 +89,7 @@ namespace SolrNet.Impl.ResponseParsers
                     var correctionNodes = cn.XPathSelectElements("lst[@name='misspellingsAndCorrections']");
                     foreach (var mc in correctionNodes.Elements())
                     {
-                        tempCollation.MisspellingsAndCorrections.Add(mc.Attribute("name").Value, mc.Value);
+                        tempCollation.MisspellingsAndCorrections.Add(new KeyValuePair<string, string>(mc.Attribute("name").Value, mc.Value));
                     }
                     r.Collations.Add(tempCollation);
                 }


### PR DESCRIPTION
Fixed issue when collation result contains duplicates in misspellings and corrections.
Example:
```xml
<lst name="collations">
      <lst name="collation">
        <str name="collationQuery">audit differences audit</str>
        <long name="hits">1111</long>
        <lst name="misspellingsAndCorrections">
          <str name="aodit">audit</str>
          <str name="differencex">differences</str>
	  <str name="aodit">audit</str>
        </lst>
      </lst>   
</lst>
```