### PR TITLE
Added AutoSolrConnection

### DIFF
--- a/AutofacContrib.SolrNet/AutofacContrib.SolrNet.csproj
+++ b/AutofacContrib.SolrNet/AutofacContrib.SolrNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.csproj
+++ b/Castle.Facilities.SolrNetIntegration/Castle.Facilities.SolrNetIntegration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.csproj
+++ b/CommonServiceLocator.SolrNet.Cloud/CommonServiceLocator.SolrNet.Cloud.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>CommonServiceLocator.SolrNet.Cloud</AssemblyName>
     <RootNamespace>CommonServiceLocator.SolrNet.Cloud</RootNamespace>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/CommonServiceLocator.SolrNet/CommonServiceLocator.SolrNet.csproj
+++ b/CommonServiceLocator.SolrNet/CommonServiceLocator.SolrNet.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>CommonServiceLocator.SolrNet</AssemblyName>
     <RootNamespace>CommonServiceLocator.SolrNet</RootNamespace>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.csproj
+++ b/Microsoft.DependencyInjection.SolrNet/Microsoft.DependencyInjection.SolrNet.csproj
@@ -7,7 +7,7 @@
     <PackageIconUrl>https://github.com/solrnet/solrnet/raw/master/Documentation/solr.png</PackageIconUrl>
     <Authors>Gidon Junge and contributors</Authors>
     <Company />
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <PackageId>SolrNet.Microsoft.DependencyInjection</PackageId>
     <Product>SolrNet.Microsoft.DependencyInjection</Product>
     <Description>SolrNet extensions for Microsoft.Extensions.DependencyInjection. SolrNet is a .NET Open Source client for Apache Solr. This version of SolrNet is compatible with Solr 1.x to Solr 7.x.</Description>

--- a/NHibernate.SolrNet/NHibernate.SolrNet.csproj
+++ b/NHibernate.SolrNet/NHibernate.SolrNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.csproj
+++ b/Ninject.Integration.SolrNet/Ninject.Integration.SolrNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/SolrNet.Cloud/SolrNet.Cloud.csproj
+++ b/SolrNet.Cloud/SolrNet.Cloud.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Authors>Mauricio Scheffer and contributors</Authors>
     <Company />
     <Product>SolrNet.Cloud.Core</Product>

--- a/SolrNet.DSL/SolrNet.DSL.csproj
+++ b/SolrNet.DSL/SolrNet.DSL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/SolrNet.Tests/AutoSolrConnectionTests.cs
+++ b/SolrNet.Tests/AutoSolrConnectionTests.cs
@@ -112,30 +112,5 @@ namespace SolrNet.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(() => conn.GetAsync("/select/", p, tokenSource.Token));
             
         }
-
-        //[Trait("Category", "Integration")]
-        //[Fact(Skip = "unknown reason")]
-        //public void ActualConnectionWithException()
-        //{
-        //    var conn = new SolrConnection(solrURL);
-        //    var p = new Dictionary<string, string>();
-        //    p["version"] = "2.1";
-        //    p["indent"] = "on";
-        //    p["q"] = "idq:123";
-        //    try
-        //    {
-        //        conn.Get("/select/", p);
-        //        Assert.True(false, "Should have thrown");
-        //    }
-        //    catch (SolrConnectionException e)
-        //    {
-        //        Console.WriteLine(e);
-        //        Console.WriteLine(e.Url);
-        //    }
-        //}
-
-
-
-
     }
 }

--- a/SolrNet.Tests/AutoSolrConnectionTests.cs
+++ b/SolrNet.Tests/AutoSolrConnectionTests.cs
@@ -1,0 +1,141 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using HttpWebAdapters;
+using Xunit;
+using Moroco;
+using SolrNet.Exceptions;
+using SolrNet.Impl;
+using System.Xml.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace SolrNet.Tests
+{
+
+    public class AutoSolrConnectionTests
+    {
+        private const string solrURL = "http://us-solr.tdnet.com:8983/solr/production"; //"http://localhost:8983/solr";
+
+        [Trait("Category", "Integration")]
+        [Fact()]
+        public void SimpleGet()
+        {
+            var p = new Dictionary<string, string>();
+            p["q"] = "*";
+            p["rows"] = "1";
+            var conn = new AutoSolrConnection(solrURL);
+            var response = conn.Get("/select/", p);
+            var xdoc = XDocument.Parse(response);
+            Assert.Equal("0", xdoc.Root.Element("lst").Elements("int").First(el => (string)el.Attribute("name") == "status").Value);
+            Assert.True(int.Parse((string)xdoc.Root.Element("result").Attribute("numFound")) > 1);
+            Assert.Single(xdoc.Root.Element("result").Elements("doc"));
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact()]
+        public async Task SimpleGetAsync()
+        {
+            var p = new Dictionary<string, string>();
+            p["q"] = "*";
+            p["rows"] = "1";
+            var conn = new AutoSolrConnection(solrURL);
+            var response = await conn.GetAsync("/select/", p);
+            var xdoc = XDocument.Parse(response);
+            Assert.Equal("0", xdoc.Root.Element("lst").Elements("int").First(el => (string)el.Attribute("name") == "status").Value);
+            Assert.True(int.Parse((string)xdoc.Root.Element("result").Attribute("numFound")) > 1);
+            Assert.Single(xdoc.Root.Element("result").Elements("doc"));
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact()]
+        public async Task GetAsyncAutoPost()
+        {
+            var p = new Dictionary<string, string>();
+            p["q"] = "*";
+            p["rows"] = "1";
+            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => "a"));
+            var conn = new AutoSolrConnection(solrURL);
+            var response = await conn.GetAsync("/select/", p);
+            var xdoc = XDocument.Parse(response);
+            Assert.Equal("0", xdoc.Root.Element("lst").Elements("int").First(el => (string)el.Attribute("name") == "status").Value);
+            Assert.True(int.Parse((string)xdoc.Root.Element("result").Attribute("numFound")) > 1);
+            Assert.Single(xdoc.Root.Element("result").Elements("doc"));
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact()]
+        public async Task GetAsyncAutoPostWithStream()
+        {
+            //No mocking yet of HTTPClient, so checked with Fiddler if indeed POST-ed
+            var p = new Dictionary<string, string>();
+            p["q"] = "*";
+            p["rows"] = "1";
+            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => "a"));
+            var conn = new AutoSolrConnection(solrURL);
+            var response = await conn.GetAsync("/select/", p, CancellationToken.None);
+            var xdoc = XDocument.Load(response);
+            Assert.Equal("0", xdoc.Root.Element("lst").Elements("int").First(el => (string)el.Attribute("name") == "status").Value);
+            Assert.True(int.Parse((string)xdoc.Root.Element("result").Attribute("numFound")) > 1);
+            Assert.Single(xdoc.Root.Element("result").Elements("doc"));
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact()]
+        public async Task GetAsyncWithCancelledToken()
+        {
+            var p = new Dictionary<string, string>();
+            p["q"] = "*";
+            p["rows"] = "1";
+            var conn = new AutoSolrConnection(solrURL);
+            var tokenSource = new CancellationTokenSource(1);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => conn.GetAsync("/select/", p, tokenSource.Token));
+            
+        }
+
+        //[Trait("Category", "Integration")]
+        //[Fact(Skip = "unknown reason")]
+        //public void ActualConnectionWithException()
+        //{
+        //    var conn = new SolrConnection(solrURL);
+        //    var p = new Dictionary<string, string>();
+        //    p["version"] = "2.1";
+        //    p["indent"] = "on";
+        //    p["q"] = "idq:123";
+        //    try
+        //    {
+        //        conn.Get("/select/", p);
+        //        Assert.True(false, "Should have thrown");
+        //    }
+        //    catch (SolrConnectionException e)
+        //    {
+        //        Console.WriteLine(e);
+        //        Console.WriteLine(e.Url);
+        //    }
+        //}
+
+
+
+
+    }
+}

--- a/SolrNet/ISolrConnection.cs
+++ b/SolrNet/ISolrConnection.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SolrNet {
@@ -74,5 +75,12 @@ namespace SolrNet {
         /// <param name="parameters">Query string parameters</param>
         /// <returns></returns>
         Task<string> GetAsync(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters);
+    }
+
+    public interface IStreamSolrConnection : ISolrConnection
+    {
+        Task<Stream> PostStreamAsync(string relativeUrl, string contentType, Stream content, IEnumerable<KeyValuePair<string, string>> getParameters, CancellationToken cancellationToken);
+        Task<Stream> GetAsync(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken);
+
     }
 }

--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -52,7 +52,7 @@ namespace SolrNet.Impl
 
         public HttpClient HttpClient { get; }
 
-        public int MaxQueryLength { get; set; } = 8192;
+        public int MaxUriLength { get; set; } = 8192;
 
         public string Get(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters) => SyncFallbackConnection.Get(relativeUrl, parameters);
 
@@ -73,8 +73,11 @@ namespace SolrNet.Impl
             u.Query = GetQuery(parameters);
 
             HttpResponseMessage response;
-            if (u.Uri.PathAndQuery.Length > MaxQueryLength)
-                response = await HttpClient.PostAsync(relativeUrl, new FormUrlEncodedContent(parameters), cancellationToken);
+            if (u.Uri.ToString().Length > MaxUriLength)
+            {
+                u.Query = null;
+                response = await HttpClient.PostAsync(u.Uri, new FormUrlEncodedContent(parameters), cancellationToken);
+            }
             else
                 response = await HttpClient.GetAsync(u.Uri, cancellationToken);
 

--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SolrNet.Exceptions;
+
+namespace SolrNet.Impl
+{
+    public class AutoSolrConnection : IStreamSolrConnection, IDisposable
+    {
+        private const string version = "2.2";
+
+        public AutoSolrConnection(string serverUrl) : this(serverUrl, credentials: null)
+        {
+
+
+        }
+
+        public AutoSolrConnection(string serverUrl, ICredentials credentials) : this(serverUrl, httpClient: null)
+        {
+            var httpClientHandler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
+                Credentials = credentials
+            };
+
+            this.HttpClient = new HttpClient(httpClientHandler);
+
+        }
+
+
+        public AutoSolrConnection(string serverUrl, HttpClient httpClient)
+        {
+            this.SyncFallbackConnection = new PostSolrConnection(new SolrConnection(serverUrl), serverUrl);
+            this.ServerURL = Utils.UriValidator.ValidateHTTP(serverUrl);
+            this.HttpClient = httpClient;
+            
+
+        }
+
+        private PostSolrConnection SyncFallbackConnection { get; }
+
+        /// <summary>
+        /// URL to Solr
+        /// </summary>
+        public string ServerURL { get; }
+
+        public HttpClient HttpClient { get; }
+
+        public int MaxQueryLength { get; set; } = 8192;
+
+        public string Get(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters) => SyncFallbackConnection.Get(relativeUrl, parameters);
+
+        public async Task<string> GetAsync(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            var responseStream = await GetAsync(relativeUrl, parameters, CancellationToken.None);
+            using (var sr = new StreamReader(responseStream))
+            {
+                return await sr.ReadToEndAsync();
+            }
+        }
+
+
+        public async Task<Stream> GetAsync(string relativeUrl, IEnumerable<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken)
+        {
+            var u = new UriBuilder(ServerURL);
+            u.Path += relativeUrl;
+            u.Query = GetQuery(parameters);
+
+            HttpResponseMessage response;
+            if (u.Uri.PathAndQuery.Length > MaxQueryLength)
+                response = await HttpClient.PostAsync(relativeUrl, new FormUrlEncodedContent(parameters), cancellationToken);
+            else
+                response = await HttpClient.GetAsync(u.Uri, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+                throw new SolrConnectionException($"{response.StatusCode}: {response.ReasonPhrase}", null, u.Uri.ToString());
+
+            return await response.Content.ReadAsStreamAsync();
+
+        }
+        public string Post(string relativeUrl, string s) => SyncFallbackConnection.Post(relativeUrl, s);
+
+        public Task<string> PostAsync(string relativeUrl, string s) => PostAsync(relativeUrl, s, CancellationToken.None);
+
+        public async Task<string> PostAsync(string relativeUrl, string s, CancellationToken cancellationToken)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            using (var content = new MemoryStream(bytes))
+            {
+                var responseStream = await PostStreamAsync(relativeUrl, "text/xml; charset=utf-8", content, null, cancellationToken);
+                using (var sr = new StreamReader(responseStream))
+                {
+                    return await sr.ReadToEndAsync();
+                }
+            }
+        }
+
+        public string PostStream(string relativeUrl, string contentType, Stream content, IEnumerable<KeyValuePair<string, string>> getParameters) => SyncFallbackConnection.PostStream(relativeUrl, contentType, content, getParameters);
+
+        public async Task<string> PostStreamAsync(string relativeUrl, string contentType, Stream content, IEnumerable<KeyValuePair<string, string>> getParameters)
+        {
+            var responseStream = await PostStreamAsync(relativeUrl, contentType, content, getParameters, CancellationToken.None);
+            using (var sr = new StreamReader(responseStream))
+            {
+                return await sr.ReadToEndAsync();
+            }
+        }
+
+
+        public async Task<Stream> PostStreamAsync(string relativeUrl, string contentType, Stream content, IEnumerable<KeyValuePair<string, string>> getParameters, CancellationToken cancellationToken)
+        {
+            var u = new UriBuilder(ServerURL);
+            u.Path += relativeUrl;
+            u.Query = GetQuery(getParameters);
+
+            var sc = new StreamContent(content);
+            sc.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(contentType);
+
+            var response = await HttpClient.PostAsync(u.Uri, sc);
+
+            if (!response.IsSuccessStatusCode)
+                throw new SolrConnectionException($"{response.StatusCode}: {response.ReasonPhrase}", null, u.Uri.ToString());
+
+            return await response.Content.ReadAsStreamAsync();
+        }
+
+
+        private string GetQuery(IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            var param = new List<KeyValuePair<string, string>>();
+            if (parameters != null)
+                param.AddRange(parameters);
+
+            param.Add(new KeyValuePair<string, string>("version", version));
+            param.Add(new KeyValuePair<string, string>("wt", "xml"));
+
+            return string.Join("&", param.Select(kv => $"{WebUtility.UrlEncode(kv.Key)}={WebUtility.UrlEncode(kv.Value)}"));
+
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    HttpClient.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
+
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+
+        #endregion
+    }
+}

--- a/SolrNet/Impl/SolrQueryExecuter.cs
+++ b/SolrNet/Impl/SolrQueryExecuter.cs
@@ -692,8 +692,19 @@ namespace SolrNet.Impl {
             var handler = options?.RequestHandler?.HandlerUrl ?? DefaultHandler;
             var param = GetAllParameters(q, options);
             var results = new SolrQueryResults<T>();
-            var r = await connection.GetAsync(handler, param);
-            var xml = XDocument.Parse(r);
+
+            XDocument xml;
+            if (connection is IStreamSolrConnection  cc)
+            {
+                var r = await cc.GetAsync(handler, param, System.Threading.CancellationToken.None);
+                xml = XDocument.Load(r);
+            }
+            else
+            {
+                var r = await connection.GetAsync(handler, param);
+                xml = XDocument.Parse(r);
+            }
+
             resultParser.Parse(xml, results);
             return results;
         }

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -6,8 +6,10 @@
     <Authors>Mauricio Scheffer and contributors</Authors>
     <Company />
     <Product>SolrNet</Product>
-    <Description>SolrNet is a .NET Open Source client for Apache Solr. This version of SolrNet is compatible with Solr 1.x to Solr 7.x.
-This is the SolrNet.Core package, and should be used in combination with any of our easy to use Dependency Injection SolrNet integration libraries.</Description>
+    <Description>
+      SolrNet is a .NET Open Source client for Apache Solr. This version of SolrNet is compatible with Solr 1.x to Solr 7.x.
+      This is the SolrNet.Core package, and should be used in combination with any of our easy to use Dependency Injection SolrNet integration libraries.
+    </Description>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>
@@ -21,7 +23,7 @@ This is the SolrNet.Core package, and should be used in combination with any of 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\SolrNet.xml</DocumentationFile>
   </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
     <DocumentationFile>bin\Release\net46\SolrNet.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
@@ -32,9 +34,12 @@ This is the SolrNet.Core package, and should be used in combination with any of 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
 
- 
-  <!-- NETSTANDARD 2.0 stuff: --><!--
+  <!-- NETSTANDARD 2.0 stuff: -->
+  <!--
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Remove="Impl\HttpRuntimeCache.cs" />
   </ItemGroup>-->

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Authors>Mauricio Scheffer and contributors</Authors>
     <Company />
     <Product>SolrNet</Product>

--- a/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.csproj
+++ b/StructureMap.SolrNetIntegration/StructureMap.SolrNetIntegration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.csproj
+++ b/Unity.SolrNetCloudIntegration/Unity.SolrNetCloudIntegration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/Unity.SolrNetIntegration/Unity.SolrNetIntegration.csproj
+++ b/Unity.SolrNetIntegration/Unity.SolrNetIntegration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <RepositoryUrl>https://github.com/solrnet/solrnet</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/SolrNet/SolrNet/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/solrnet/solrnet</PackageProjectUrl>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.6 
+- New: `AutoSolrConnection`, automatically uses `GET` or `POST` depending on uri length. Improved performance when using `async` methods. 
+
 ## 1.0.5 
 - SolrNet Cloud: add checks if Zookeeper connection is valid
 


### PR DESCRIPTION
* `HttpClient` instead of `HttpWebRequest` to perform requests to Solr, making cleaner code, and out-of-the-box instrumentation by 3rd party libraries such NewRelic.
* Auto `POST`s when the `GET` uri is too long.
* Falls back to `PostSolrConnection` for sync methods
* New `GetAsync`/`PostAsync` method with `CancellationToken` support, and return of` Stream` instead of `string` for improved performance. (We can feed a stream into the `XDocument`, instead of first creation a string, and then parsing that string into the `XDocument`).

