### PR TITLE
Use AutoSolrConnection instead of SolrConnection in StructureMap.SolrNetIntegration

### DIFF
--- a/Documentation/Initialization.md
+++ b/Documentation/Initialization.md
@@ -78,11 +78,12 @@ Install-Package SolrNet.StructureMap
 If you are using StructureMap, you can use the StructureMap module (`StructureMap.SolrNetIntegration`):
 
 ```C#
-ObjectFactory.Initialize(
-    x => x.AddRegistry(
-        new SolrNetRegistry("http://localhost:8893/solr")
-    )
-);
+IEnumerable<SolrServer> solrServers = new[]
+{
+	new SolrServer(id: "test", url: "http://localhost:8893", documentType: "testDocumentType")
+};
+
+var container = new StructureMap.Container(SolrNetRegistry.Create(solrServers));
 ```
 
 ### Autofac
@@ -109,7 +110,7 @@ Install-Package SolrNet.Autofac
 var solrServers = new SolrServers {
         new SolrServerElement {
           Id = "test",
-          Url = "htp://localhost:8893",
+          Url = "http://localhost:8893",
           DocumentType = typeof (Entity).AssemblyQualifiedName,
         }
 };

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapFixture.cs
@@ -5,10 +5,10 @@ using SolrNet.Exceptions;
 using SolrNet.Impl;
 using Microsoft.Extensions.Configuration;
 using System.IO;
-using System.IO;
 using System.Configuration;
 using StructureMap.SolrNetIntegration.Config;
 using System.Linq;
+
 namespace StructureMap.SolrNetIntegration.Tests
 {
 
@@ -23,7 +23,7 @@ namespace StructureMap.SolrNetIntegration.Tests
                 new SolrServer ("entity2","http://localhost:8983/solr/core0", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests"),
                 new SolrServer ("entity3","http://localhost:8983/solr/core1", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests")
             };
-            Container = new Container(c => c.IncludeRegistry(new SolrNetRegistry(servers)));
+            Container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(servers)));
         }
 
 
@@ -40,11 +40,11 @@ namespace StructureMap.SolrNetIntegration.Tests
         {
 
             var solrConfig = (SolrConfigurationSection)ConfigurationManager.GetSection("solr");
-            var container = new Container(c => c.IncludeRegistry(new SolrNetRegistry(solrConfig.SolrServers)));
+            var container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(solrConfig.SolrServers)));
 
             var instanceKey = "entity" + typeof(SolrConnection);
 
-            var solrConnection = (SolrConnection)container.GetInstance<ISolrConnection>(instanceKey);
+            var solrConnection = (AutoSolrConnection)container.GetInstance<ISolrConnection>(instanceKey);
 
             Assert.Equal("http://localhost:8983/solr/collection1", solrConnection.ServerURL);
         }
@@ -77,12 +77,12 @@ namespace StructureMap.SolrNetIntegration.Tests
                .Build()
                .GetSection("solr:servers");
 
-            var container = new Container(c => c.IncludeRegistry(new SolrNetRegistry(configuration.Get<List<SolrServer>>())));
+            var container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(configuration.Get<List<SolrServer>>())));
 
 
             var instanceKey = "entity" + typeof(SolrConnection);
 
-            var solrConnection = (SolrConnection)container.GetInstance<ISolrConnection>(instanceKey);
+            var solrConnection = (AutoSolrConnection)container.GetInstance<ISolrConnection>(instanceKey);
 
             Assert.Equal("http://localhost:8983/solr/collection1", solrConnection.ServerURL);
         }
@@ -120,7 +120,7 @@ namespace StructureMap.SolrNetIntegration.Tests
                     DocumentType = typeof(Entity2).AssemblyQualifiedName,
                 }
             };
-            Assert.Throws<InvalidURLException>(() => new Container(c => c.IncludeRegistry(new SolrNetRegistry(solrServers))));
+            Assert.Throws<InvalidURLException>(() => new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(solrServers))));
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace StructureMap.SolrNetIntegration.Tests
                 }
             };
 
-            Assert.Throws<InvalidURLException>(() => new Container(c => c.IncludeRegistry(new SolrNetRegistry(solrServers))));
+            Assert.Throws<InvalidURLException>(() => new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(solrServers))));
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace StructureMap.SolrNetIntegration.Tests
                     Url = "http://localhost:8983/solr/entity2",
                 },
             };
-            var container = new Container(c => c.IncludeRegistry(new SolrNetRegistry(cores)));
+            var container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(cores)));
             var solr1 = container.GetInstance<ISolrOperations<Entity>>();
             var solr2 = container.GetInstance<ISolrOperations<Entity2>>();
             var solrDict = container.GetInstance<ISolrOperations<Dictionary<string, object>>>();

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
@@ -26,7 +26,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
                 new SolrServer ("entity2","http://localhost:8983/solr/core0", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests"),
                 new SolrServer ("entity3","http://localhost:8983/solr/core1", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests")
             };
-            Container = new Container(c => c.IncludeRegistry(new SolrNetRegistry(servers)));
+            Container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(servers)));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
                 }
             };
 
-            Container.Configure(c => c.AddRegistry(new SolrNetRegistry(cores)));
+            Container.Configure(c => c.AddRegistry(SolrNetRegistry.Create(cores)));
 
             var solr = Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
             var results = solr.Query(SolrQuery.All);
@@ -72,7 +72,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
                 }
             };
 
-            Container.Configure(c=>c.AddRegistry(new SolrNetRegistry(cores)));
+            Container.Configure(c=>c.AddRegistry(SolrNetRegistry.Create(cores)));
 
             var solr = Container.GetInstance<ISolrOperations<Dictionary<string, object>>>();
 

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapMultiCoreFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapMultiCoreFixture.cs
@@ -35,7 +35,7 @@ namespace StructureMap.SolrNetIntegration.Tests
                     s.Assembly(typeof(SolrConnection).Assembly);
                     s.WithDefaultConventions();
                 });
-                c.AddRegistry(new SolrNetRegistry(servers));
+                c.AddRegistry(SolrNetRegistry.Create(servers));
             });
             
         }

--- a/StructureMap.SolrNetIntegration/SolrNetRegistry.cs
+++ b/StructureMap.SolrNetIntegration/SolrNetRegistry.cs
@@ -19,9 +19,18 @@ namespace StructureMap.SolrNetIntegration
 {
     public class SolrNetRegistry : Registry
     {
-        // Constructor should not be used to create SolrNetRegistry as it's 
-        private SolrNetRegistry()
+        // Constructor should not be used to create SolrNetRegistry we use virtual methods during the initialization. Use Initialize instead.       
+        protected SolrNetRegistry()
         {
+
+        }
+
+        [Obsolete("Use static Create method instead. This constructor shouldn't be used from child classes at it may cause unexpected behaviour (it won't not use overriden methods).")]
+        public SolrNetRegistry(IEnumerable<ISolrServer> solrServers)
+        {
+
+#warning This is unsafe! This will cause troubles on inheritance!
+            this.Initialize(solrServers);
         }
 
         public static SolrNetRegistry Create(IEnumerable<ISolrServer> solrServers)
@@ -106,7 +115,7 @@ namespace StructureMap.SolrNetIntegration
 
             For<ISolrConnection>().Use(() => new AutoSolrConnection(coreUrl))
                 .Named(coreConnectionId);
-            
+
             var ISolrQueryExecuter = typeof(ISolrQueryExecuter<>).MakeGenericType(documentType);
             var SolrQueryExecuter = typeof(SolrQueryExecuter<>).MakeGenericType(documentType);
 
@@ -134,7 +143,7 @@ namespace StructureMap.SolrNetIntegration
         }
 
         protected virtual void RegisterServers(IEnumerable<ISolrServer> servers)
-        {            
+        {
             foreach (var server in servers)
             {
                 RegisterCore(server.Id ?? Guid.NewGuid().ToString(), GetCoreDocumentType(server), GetCoreUrl(server));
@@ -146,7 +155,7 @@ namespace StructureMap.SolrNetIntegration
             var url = server.Url;
             if (string.IsNullOrEmpty(url))
                 throw new StructureMapConfigurationException("Core url missing in SolrNet core configuration");
-            
+
             UriValidator.ValidateHTTP(url);
             return url;
         }


### PR DESCRIPTION
Changed implementation for ISolrConnection from SolrConnection to AutoSolrConnection
Changed the class to be more extensible
Updated test fixtures

Warning: Interface has changed. 
SolrNetRegistry must be created with SolrNetRegistry.Create static method instead of constructor. 
This had to be done in order to safely use virtual methods at initialization time.