### PR TITLE
MS Dependency Injection update

### DIFF
--- a/Microsoft.DependencyInjection.SolrNet.Tests/MicrosoftDependencyFixture.cs
+++ b/Microsoft.DependencyInjection.SolrNet.Tests/MicrosoftDependencyFixture.cs
@@ -74,10 +74,10 @@ namespace Microsoft.DependencyInjection.SolrNet.Tests
         public void CannotResolveSolrAbstractResponseParsersViaArray()
         {
             //MS Dependency injection doesn't support 
-            Assert.Throws<InvalidOperationException>(() => 
+            Assert.Throws<InvalidOperationException>(() =>
                 DefaultServiceProvider.GetRequiredService<ISolrAbstractResponseParser<Entity>[]>()
             );
-            
+
         }
 
 
@@ -106,6 +106,27 @@ namespace Microsoft.DependencyInjection.SolrNet.Tests
             Assert.NotNull(solr);
         }
 
+
+
+        [Fact]
+        public void SetBasicAuthenticationHeader()
+        {
+            var sc = new ServiceCollection();
+
+            //my credentials
+            var credentials = System.Text.Encoding.ASCII.GetBytes("myUsername:myPassword");
+            //in base64
+            var credentialsBase64 = Convert.ToBase64String(credentials);
+            //use the options to set the Authorization header.
+            sc.AddSolrNet("http://localhost:8983/solr", options => { options.HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", credentialsBase64); });
+
+            //test
+            var provider = sc.BuildServiceProvider();
+            var connection = provider.GetRequiredService<ISolrConnection>() as AutoSolrConnection;
+
+            Assert.NotNull(connection.HttpClient.DefaultRequestHeaders.Authorization);
+            Assert.Equal(credentialsBase64, connection.HttpClient.DefaultRequestHeaders.Authorization.Parameter);
+        }
 
         public class Entity { }
     }

--- a/Microsoft.DependencyInjection.SolrNet/SolrNetOptions.cs
+++ b/Microsoft.DependencyInjection.SolrNet/SolrNetOptions.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+
+namespace SolrNet
+{
+    public class SolrNetOptions
+    {
+        public SolrNetOptions(HttpClient httpClient)
+        {
+            HttpClient = httpClient;
+        }
+
+        /// <summary>
+        /// Gets the HttpClient with which SolrNet connects to the Solr server. This is the place to add Default Headers for Basic Authentication for example..
+        /// </summary>
+        public HttpClient HttpClient { get; }
+    }
+}


### PR DESCRIPTION
* Switch to Singleton AutoSolrConnection
* Add override to IServiceCollection.AddSolrNet , allowing to set injection options. Currently only supporting tweaking the HttpClient in use by the AutoSolrConnection.
* Add unit test showing the use of Basic Authentication.

Fixes #402