### PR TITLE
Issue-435: Added support for percentiles in stats queries

### DIFF
--- a/SolrNet.Tests/Resources/responseWithStats.xml
+++ b/SolrNet.Tests/Resources/responseWithStats.xml
@@ -16,6 +16,10 @@
         <double name="sumOfSquares">6038619.160300001</double>
         <double name="mean">350.08466666666664</double>
         <double name="stddev">547.737557906113</double>
+        <lst name="percentiles">
+          <double name="50.0">36000.0</double>
+          <double name="75.0">38495.0</double>
+        </lst>
         <lst name="facets">
           <lst name="inStock">
             <lst name="false">

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -861,6 +861,8 @@ namespace SolrNet.Tests
             Assert.Equal(1, priceStats.FacetResults.Count);
             Assert.True(priceStats.FacetResults.ContainsKey("inStock"));
             var priceInStockStats = priceStats.FacetResults["inStock"];
+            Assert.NotNull(priceStats.Percentiles);
+            Assert.Equal(36000.0, priceStats.Percentiles[50]);
             Assert.Equal(2, priceInStockStats.Count);
             Assert.True(priceInStockStats.ContainsKey("true"));
             Assert.True(priceInStockStats.ContainsKey("false"));

--- a/SolrNet/Impl/ResponseParsers/StatsResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/StatsResponseParser.cs
@@ -64,6 +64,21 @@ namespace SolrNet.Impl.ResponseParsers {
             return r;
         }
 
+        /// <summary>
+        /// Parses percentiles node.
+        /// </summary>
+        /// <param name="node">Percentile node.</param>
+        /// <returns></returns>
+        public IDictionary<double, double> ParsePercentilesNode(XElement node) {
+            var r = new Dictionary<double, double>();
+
+            foreach (var n in node.Elements()) {
+                var percentile = Convert.ToDouble(n.Attribute("name").Value, CultureInfo.InvariantCulture);
+                r.Add(percentile, GetDoubleValue(n));
+            }
+            return r;
+        }
+
         public StatsResult ParseStatsNode(XElement node) {
             var r = new StatsResult();
             foreach (var statNode in node.Elements()) {
@@ -88,10 +103,13 @@ namespace SolrNet.Impl.ResponseParsers {
                         r.StdDev = GetDoubleValue(statNode);
                         break;
                     case "count":
-						r.Count = Convert.ToInt64( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Count = Convert.ToInt64( statNode.Value, CultureInfo.InvariantCulture );
                         break;
                     case "missing":
-						r.Missing = Convert.ToInt64( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Missing = Convert.ToInt64( statNode.Value, CultureInfo.InvariantCulture );
+                        break;
+                    case "percentiles":
+                        r.Percentiles = ParsePercentilesNode(statNode);
                         break;
                     default:
                         r.FacetResults = ParseFacetNode(statNode);

--- a/SolrNet/StatsResult.cs
+++ b/SolrNet/StatsResult.cs
@@ -63,6 +63,11 @@ namespace SolrNet {
         public double StdDev { get; set; }
 
         /// <summary>
+        /// A list of percentile values based on cut-off points specified.
+        /// </summary>
+        public IDictionary<double, double> Percentiles { get; set; }
+
+        /// <summary>
         /// Facet results.
         /// <list type="bullet">
         /// <item>Key is the facet field</item>


### PR DESCRIPTION
I added a property named Percentiles to StatsResult class. Then modified StatsResponseParser to parse and set all percentiles present in the response.