### PR TITLE
Fix broken unit tests due to PR #439

### DIFF
--- a/SolrNet.Tests/SolrDictionarySerializerTests.cs
+++ b/SolrNet.Tests/SolrDictionarySerializerTests.cs
@@ -106,7 +106,7 @@ namespace SolrNet.Tests
         {
             var serializer = GetSerializer();
             var xml = serializer.Serialize(new Dictionary<string, object> {
-                {"one", new DateTime(2000, 1, 2, 12, 23, 34)}
+                {"one", new DateTime(2000, 1, 2, 12, 23, 34, DateTimeKind.Utc)}
             }, null);
             AssertSerializedField(xml, "2000-01-02T12:23:34Z");
         }

--- a/SolrNet.Tests/SolrDocumentSerializerTests.cs
+++ b/SolrNet.Tests/SolrDocumentSerializerTests.cs
@@ -22,106 +22,120 @@ using SolrNet.Impl;
 using SolrNet.Impl.FieldSerializers;
 using SolrNet.Mapping;
 
-namespace SolrNet.Tests {
-	
-	public partial class SolrDocumentSerializerTests {
-		[Fact]
-		public void Serializes() {
-		    var mapper = new AttributesMappingManager();
-			var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
-			var doc = new SampleDoc {Id = "id", Dd = 23.5m};
-			string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"Id\">id</field><field name=\"Flower\">23.5</field></doc>", fs);
-		}
+namespace SolrNet.Tests
+{
 
-		[Fact]
-		public void SupportsCollections() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithCollections();
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"coll\">one</field><field name=\"coll\">two</field></doc>", fs);
-		}
-
-		[Fact]
-		public void EscapesStrings() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
-			var doc = new SampleDoc {Id = "<quote\""};
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-            Assert.Equal("<doc><field name=\"Id\">&lt;quote\"</field><field name=\"Flower\">0</field></doc>", fs);
-		}
-
-		[Fact]
-		public void AcceptsNullObjects() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
-			var doc = new SampleDoc {Id = null};
-            ser.Serialize(doc, null).ToString();
-		}
-
-		[Fact]
-		public void AcceptsSparseCollections() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithCollections { coll = new[] { "one", null, "two" } };
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"coll\">one</field><field name=\"coll\">two</field></doc>", fs);
-		}
-
-		[Fact]
-		public void AcceptsEmptyCollections() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithCollections { coll = new string[] { null, null } };
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc />", fs);
-		}
-
-		/// <summary>
-		/// Support according to http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
-		/// </summary>
-		[Fact]
-		public void SupportsDateTime() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithDate>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithDate {Date = new DateTime(2001, 1, 2, 3, 4, 5)};
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"Date\">2001-01-02T03:04:05Z</field></doc>", fs);
-		}
-
-		[Fact]
-		public void SupportsBoolTrue() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithBool>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithBool {B = true};
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"B\">true</field></doc>", fs);
-		}
-
-		[Fact]
-		public void SupportsBoolFalse() {
-            var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithBool>(mapper, new DefaultFieldSerializer());
-			var doc = new TestDocWithBool {B = false};
-            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-			Assert.Equal("<doc><field name=\"B\">false</field></doc>", fs);
-		}
-
+    public partial class SolrDocumentSerializerTests
+    {
         [Fact]
-        public void SupportsGuid() {
+        public void Serializes()
+        {
             var mapper = new AttributesMappingManager();
-            var ser = new SolrDocumentSerializer<TestDocWithGuid>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithGuid {Key = Guid.NewGuid()};
+            var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
+            var doc = new SampleDoc { Id = "id", Dd = 23.5m };
             string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
-            Assert.Equal("<doc><field name=\"Key\">"+doc.Key+"</field></doc>", fs);
+            Assert.Equal("<doc><field name=\"Id\">id</field><field name=\"Flower\">23.5</field></doc>", fs);
         }
 
         [Fact]
-        public void SupportsGenericDictionary_empty() {
+        public void SupportsCollections()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithCollections();
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"coll\">one</field><field name=\"coll\">two</field></doc>", fs);
+        }
+
+        [Fact]
+        public void EscapesStrings()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
+            var doc = new SampleDoc { Id = "<quote\"" };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"Id\">&lt;quote\"</field><field name=\"Flower\">0</field></doc>", fs);
+        }
+
+        [Fact]
+        public void AcceptsNullObjects()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<SampleDoc>(mapper, new DefaultFieldSerializer());
+            var doc = new SampleDoc { Id = null };
+            ser.Serialize(doc, null).ToString();
+        }
+
+        [Fact]
+        public void AcceptsSparseCollections()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithCollections { coll = new[] { "one", null, "two" } };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"coll\">one</field><field name=\"coll\">two</field></doc>", fs);
+        }
+
+        [Fact]
+        public void AcceptsEmptyCollections()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithCollections>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithCollections { coll = new string[] { null, null } };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc />", fs);
+        }
+
+        /// <summary>
+        /// Support according to http://lucene.apache.org/solr/api/org/apache/solr/schema/DateField.html
+        /// </summary>
+        [Fact]
+        public void SupportsDateTime()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithDate>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithDate { Date = new DateTime(2001, 1, 2, 3, 4, 5, DateTimeKind.Utc) };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"Date\">2001-01-02T03:04:05Z</field></doc>", fs);
+        }
+
+        [Fact]
+        public void SupportsBoolTrue()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithBool>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithBool { B = true };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"B\">true</field></doc>", fs);
+        }
+
+        [Fact]
+        public void SupportsBoolFalse()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithBool>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithBool { B = false };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"B\">false</field></doc>", fs);
+        }
+
+        [Fact]
+        public void SupportsGuid()
+        {
+            var mapper = new AttributesMappingManager();
+            var ser = new SolrDocumentSerializer<TestDocWithGuid>(mapper, new DefaultFieldSerializer());
+            var doc = new TestDocWithGuid { Key = Guid.NewGuid() };
+            string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
+            Assert.Equal("<doc><field name=\"Key\">" + doc.Key + "</field></doc>", fs);
+        }
+
+        [Fact]
+        public void SupportsGenericDictionary_empty()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithGenDict>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithGenDict {
+            var doc = new TestDocWithGenDict
+            {
                 Id = 5,
                 Dict = new Dictionary<string, string>(),
             };
@@ -130,10 +144,12 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void SupportsGenericDictionary_string_string() {
+        public void SupportsGenericDictionary_string_string()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithGenDict>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithGenDict {
+            var doc = new TestDocWithGenDict
+            {
                 Id = 5,
                 Dict = new Dictionary<string, string> {
                     {"one", "1"},
@@ -145,10 +161,12 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void SupportsGenericDictionary_string_int() {
+        public void SupportsGenericDictionary_string_int()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithGenDict2>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithGenDict2 {
+            var doc = new TestDocWithGenDict2
+            {
                 Id = 5,
                 Dict = new Dictionary<string, int> {
                     {"one", 1},
@@ -160,15 +178,17 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void SupportsGenericDictionary_rest() {
+        public void SupportsGenericDictionary_rest()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithGenDict3>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithGenDict3 {
+            var doc = new TestDocWithGenDict3
+            {
                 Id = 5,
                 Dict = new Dictionary<string, object> {
                     {"one", 1},
                     {"two", 2},
-                    {"fecha", new DateTime(2010, 1, 1)},
+                    {"fecha", new DateTime(2010, 1, 1,0,0,0, DateTimeKind.Utc)},
                     {"SomeCollection", new[] {"a", "b", "c"}},
                 },
             };
@@ -177,7 +197,8 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void SupportsNullableDateTime() {
+        public void SupportsNullableDateTime()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithNullableDate>(mapper, new DefaultFieldSerializer());
             var doc = new TestDocWithNullableDate();
@@ -186,10 +207,12 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void UTF_XML() {
+        public void UTF_XML()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithString>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithString {
+            var doc = new TestDocWithString
+            {
                 Desc = @"ÚóÁ⌠╒"""
             };
             string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
@@ -197,21 +220,25 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void DocumentBoost() {
+        public void DocumentBoost()
+        {
             var mapper = new AttributesMappingManager();
             ISolrDocumentSerializer<TestDocWithString> ser = new SolrDocumentSerializer<TestDocWithString>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithString {
+            var doc = new TestDocWithString
+            {
                 Desc = "hello"
             };
             string fs = ser.Serialize(doc, 2.1).ToString(SaveOptions.DisableFormatting);
-            Assert.Equal(@"<doc boost=""2.1""><field name=""Desc"">hello</field></doc>", fs);            
+            Assert.Equal(@"<doc boost=""2.1""><field name=""Desc"">hello</field></doc>", fs);
         }
 
         [Fact]
-        public void FieldBoost() {
+        public void FieldBoost()
+        {
             var mapper = new AttributesMappingManager();
             ISolrDocumentSerializer<TestDocWithBoostedString> ser = new SolrDocumentSerializer<TestDocWithBoostedString>(mapper, new DefaultFieldSerializer());
-            var doc = new TestDocWithBoostedString {
+            var doc = new TestDocWithBoostedString
+            {
                 Desc = "hello"
             };
             string fs = ser.Serialize(doc, null).ToString(SaveOptions.DisableFormatting);
@@ -219,10 +246,12 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void Inheritance() {
+        public void Inheritance()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithString>(mapper, new DefaultFieldSerializer());
-            var doc = new InheritedDoc {
+            var doc = new InheritedDoc
+            {
                 Desc = "Description",
                 Desc1 = "Description1"
             };
@@ -231,14 +260,16 @@ namespace SolrNet.Tests {
         }
 
         [Fact]
-        public void PropertyWithoutGetter() {
+        public void PropertyWithoutGetter()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithoutGetter>(mapper, new DefaultFieldSerializer());
             string fs = ser.Serialize(new TestDocWithoutGetter(), null).ToString();
         }
 
         [Fact]
-        public void Location() {
+        public void Location()
+        {
             var mapper = new AttributesMappingManager();
             var ser = new SolrDocumentSerializer<TestDocWithLocation>(mapper, new DefaultFieldSerializer());
             var testDoc = new TestDocWithLocation { Loc = new Location(12.2, -12.3) };
@@ -246,5 +277,5 @@ namespace SolrNet.Tests {
             Assert.Equal(@"<doc><field name=""location"">12.2,-12.3</field></doc>", fs);
         }
 
-	}
+    }
 }

--- a/SolrNet.Tests/SolrFacetDateQueryTests.cs
+++ b/SolrNet.Tests/SolrFacetDateQueryTests.cs
@@ -23,47 +23,53 @@ using SolrNet.Impl.FieldSerializers;
 using SolrNet.Impl.QuerySerializers;
 using SolrNet.Utils;
 
-namespace SolrNet.Tests {
-    
-    public class SolrFacetDateQueryTests {
+namespace SolrNet.Tests
+{
+
+    public class SolrFacetDateQueryTests
+    {
 
         [Fact]
-        #pragma warning disable xUnit1024 // Test methods cannot have overloads
+#pragma warning disable xUnit1024 // Test methods cannot have overloads
         public void Serialize()
         {
-            var q = new SolrFacetDateQuery("timestamp", new DateTime(2009,1,1), new DateTime(2009,2,2), "+1DAY") {
-                HardEnd = true,
-                Other = new[] {FacetDateOther.After},
-                Include = new[] { FacetDateInclude.Lower },
-            };
-            var r = Serialize(q);
-            Assert.Contains( KV.Create("facet.date", "timestamp"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.start", "2009-01-01T00:00:00Z"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.end", "2009-02-02T00:00:00Z"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.gap", "+1DAY"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.hardend", "true"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.other", "after"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.include", "lower"),r);
-        }
-        
-        [Fact]
-        public void IgnoresLocalParams() {
-            var q = new SolrFacetDateQuery(new LocalParams { { "ex", "cat" } } + "timestamp", new DateTime(2009, 1, 1), new DateTime(2009, 2, 2), "+1DAY") {
+            var q = new SolrFacetDateQuery("timestamp", new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2009, 2, 2, 0, 0, 0, DateTimeKind.Utc), "+1DAY")
+            {
                 HardEnd = true,
                 Other = new[] { FacetDateOther.After },
                 Include = new[] { FacetDateInclude.Lower },
             };
             var r = Serialize(q);
-            Assert.Contains( KV.Create("facet.date", "{!ex=cat}timestamp"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.start", "2009-01-01T00:00:00Z"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.end", "2009-02-02T00:00:00Z"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.gap", "+1DAY"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.hardend", "true"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.other", "after"),r);
-            Assert.Contains( KV.Create("f.timestamp.facet.date.include", "lower"),r);
+            Assert.Contains(KV.Create("facet.date", "timestamp"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.start", "2009-01-01T00:00:00Z"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.end", "2009-02-02T00:00:00Z"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.gap", "+1DAY"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.hardend", "true"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.other", "after"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.include", "lower"), r);
         }
 
-        private static IList<KeyValuePair<string, string>> Serialize(object o) {
+        [Fact]
+        public void IgnoresLocalParams()
+        {
+            var q = new SolrFacetDateQuery(new LocalParams { { "ex", "cat" } } + "timestamp", new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2009, 2, 2, 0, 0, 0, DateTimeKind.Utc), "+1DAY")
+            {
+                HardEnd = true,
+                Other = new[] { FacetDateOther.After },
+                Include = new[] { FacetDateInclude.Lower },
+            };
+            var r = Serialize(q);
+            Assert.Contains(KV.Create("facet.date", "{!ex=cat}timestamp"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.start", "2009-01-01T00:00:00Z"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.end", "2009-02-02T00:00:00Z"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.gap", "+1DAY"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.hardend", "true"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.other", "after"), r);
+            Assert.Contains(KV.Create("f.timestamp.facet.date.include", "lower"), r);
+        }
+
+        private static IList<KeyValuePair<string, string>> Serialize(object o)
+        {
             var fieldSerializer = new DefaultFieldSerializer();
             var serializer = new DefaultFacetQuerySerializer(new DefaultQuerySerializer(fieldSerializer), fieldSerializer);
             return serializer.Serialize(o).ToList();

--- a/SolrNet.Tests/SolrFacetIntervalQueryTests.cs
+++ b/SolrNet.Tests/SolrFacetIntervalQueryTests.cs
@@ -32,8 +32,8 @@ namespace SolrNet.Tests
         public void SerializeWithDateOneItem()
         {
             var q = new SolrFacetIntervalQuery("timestamp");
-            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue(new DateTime(2009, 1, 1), true), new FacetIntervalSetValue(new DateTime(2010, 1, 1), true)));
-          
+            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue(new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Utc), true), new FacetIntervalSetValue(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc), true)));
+
             var r = Serialize(q);
             Assert.Contains(KV.Create("facet.interval", "timestamp"), r);
             Assert.Contains(KV.Create("f.timestamp.facet.interval.set", "[2009-01-01T00:00:00Z,2010-01-01T00:00:00Z]"), r);
@@ -77,7 +77,7 @@ namespace SolrNet.Tests
         public void SerializeWithEndUnbound()
         {
             var q = new SolrFacetIntervalQuery("state");
-            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue("az", true),null));
+            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue("az", true), null));
 
             var r = Serialize(q);
             Assert.Contains(KV.Create("facet.interval", "state"), r);
@@ -124,7 +124,7 @@ namespace SolrNet.Tests
             var q = new SolrFacetIntervalQuery("state");
             var lp = new LocalParams();
             lp.Add("key", "arizonatopen");
-            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue("az", false), new FacetIntervalSetValue("pa", false), lp));             
+            q.Sets.Add(new FacetIntervalSet(new FacetIntervalSetValue("az", false), new FacetIntervalSetValue("pa", false), lp));
 
             var r = Serialize(q);
             Assert.Contains(KV.Create("facet.interval", "state"), r);

--- a/SolrNet.Tests/SolrFacetRangeQueryTests.cs
+++ b/SolrNet.Tests/SolrFacetRangeQueryTests.cs
@@ -31,7 +31,7 @@ namespace SolrNet.Tests
         [Fact]
         public void SerializeWithDate()
         {
-            var q = new SolrFacetRangeQuery("timestamp", new DateTime(2009, 1, 1), new DateTime(2009, 2, 2), "+1DAY")
+            var q = new SolrFacetRangeQuery("timestamp", new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2009, 2, 2, 0, 0, 0, DateTimeKind.Utc), "+1DAY")
             {
                 HardEnd = true,
                 Other = new[] { FacetRangeOther.After },
@@ -72,7 +72,7 @@ namespace SolrNet.Tests
         [Fact]
         public void IgnoresLocalParams()
         {
-            var q = new SolrFacetRangeQuery(new LocalParams { { "ex", "cat" } } + "timestamp", new DateTime(2009, 1, 1), new DateTime(2009, 2, 2), "+1DAY")
+            var q = new SolrFacetRangeQuery(new LocalParams { { "ex", "cat" } } + "timestamp", new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2009, 2, 2, 0, 0, 0, DateTimeKind.Utc), "+1DAY")
             {
                 HardEnd = true,
                 Other = new[] { FacetRangeOther.After },

--- a/SolrNet.Tests/SolrQueryByRangeTests.cs
+++ b/SolrNet.Tests/SolrQueryByRangeTests.cs
@@ -19,62 +19,73 @@ using Xunit;
 using SolrNet.Impl.FieldSerializers;
 using SolrNet.Impl.QuerySerializers;
 
-namespace SolrNet.Tests {
-	
-	public class SolrQueryByRangeTests {
-		public class TestDocument {}
+namespace SolrNet.Tests
+{
 
-        public string Serialize(object q) {
+    public class SolrQueryByRangeTests
+    {
+        public class TestDocument { }
+
+        public string Serialize(object q)
+        {
             var serializer = new DefaultQuerySerializer(new DefaultFieldSerializer());
             return serializer.Serialize(q);
         }
 
 
-		[Fact]
-		public void IntInclusive() {
-			var q = new SolrQueryByRange<int>("id", 123, 456);
-			Assert.Equal("id:[123 TO 456]", Serialize(q));
-		}
-
-		[Fact]
-		public void StringInclusive() {
-			var q = new SolrQueryByRange<string>("id", "Arroz", "Zimbabwe");
-			Assert.Equal("id:[Arroz TO Zimbabwe]", Serialize(q));
-		}
-
-		[Fact]
-		public void StringExclusive() {
-			var q = new SolrQueryByRange<string>("id", "Arroz", "Zimbabwe", false);
-			Assert.Equal("id:{Arroz TO Zimbabwe}", Serialize(q));
-		}
+        [Fact]
+        public void IntInclusive()
+        {
+            var q = new SolrQueryByRange<int>("id", 123, 456);
+            Assert.Equal("id:[123 TO 456]", Serialize(q));
+        }
 
         [Fact]
-        public void FloatInclusive() {
+        public void StringInclusive()
+        {
+            var q = new SolrQueryByRange<string>("id", "Arroz", "Zimbabwe");
+            Assert.Equal("id:[Arroz TO Zimbabwe]", Serialize(q));
+        }
+
+        [Fact]
+        public void StringExclusive()
+        {
+            var q = new SolrQueryByRange<string>("id", "Arroz", "Zimbabwe", false);
+            Assert.Equal("id:{Arroz TO Zimbabwe}", Serialize(q));
+        }
+
+        [Fact]
+        public void FloatInclusive()
+        {
             var q = new SolrQueryByRange<float>("price", 123.45f, 234.56f);
             Assert.Equal("price:[123.45 TO 234.56]", Serialize(q));
         }
 
         [Fact]
-        public void NullableFloat() {
+        public void NullableFloat()
+        {
             var q = new SolrQueryByRange<float?>("price", null, 234.56f);
             Assert.Equal("price:[* TO 234.56]", Serialize(q));
         }
 
         [Fact]
-        public void DateTimeInclusive() {
-            var q = new SolrQueryByRange<DateTime>("ts", new DateTime(2001, 1, 5), new DateTime(2002, 3, 4, 5, 6, 7));
+        public void DateTimeInclusive()
+        {
+            var q = new SolrQueryByRange<DateTime>("ts", new DateTime(2001, 1, 5, 0, 0, 0, DateTimeKind.Utc), new DateTime(2002, 3, 4, 5, 6, 7, DateTimeKind.Utc));
             Assert.Equal("ts:[2001-01-05T00:00:00Z TO 2002-03-04T05:06:07Z]", Serialize(q));
         }
 
         [Fact]
-        public void NullableDateTime() {
-            var q = new SolrQueryByRange<DateTime?>("ts", new DateTime(2001, 1, 5), new DateTime(2002, 3, 4, 5, 6, 7));
+        public void NullableDateTime()
+        {
+            var q = new SolrQueryByRange<DateTime?>("ts", new DateTime(2001, 1, 5, 0, 0, 0, DateTimeKind.Utc), new DateTime(2002, 3, 4, 5, 6, 7,  DateTimeKind.Utc));
             Assert.Equal("ts:[2001-01-05T00:00:00Z TO 2002-03-04T05:06:07Z]", Serialize(q));
         }
 
         [Fact]
-        public void NullableDateTimeWithNull() {
-            var q = new SolrQueryByRange<DateTime?>("ts", null, new DateTime(2002, 3, 4, 5, 6, 7));
+        public void NullableDateTimeWithNull()
+        {
+            var q = new SolrQueryByRange<DateTime?>("ts", null, new DateTime(2002, 3, 4, 5, 6, 7, DateTimeKind.Utc));
             Assert.Equal("ts:[* TO 2002-03-04T05:06:07Z]", Serialize(q));
         }
 


### PR DESCRIPTION
See #439  
this fix declares the `DateTime` objects used in the unit tests as `Utc`