### PR TITLE
Fix json serialization issues in AtomicUpdateCommand

### DIFF
--- a/SolrNet.Tests/AtomicUpdateCommandTests.cs
+++ b/SolrNet.Tests/AtomicUpdateCommandTests.cs
@@ -318,5 +318,39 @@ namespace SolrNet.Tests
             cmd.Execute(conn);
             Assert.Equal(1, conn.postStream.Calls);
         }
+
+        [Fact]
+        public void AtomicUpdateNullStringValue()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"set\":null}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Set, (String)null) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
+
+        [Fact]
+        public void AtomicUpdateNullStringArrayValue()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"food\":{\"set\":null}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("food", AtomicUpdateType.Set, (String[])null) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
     }
 }

--- a/SolrNet/Commands/AtomicUpdateCommand.cs
+++ b/SolrNet/Commands/AtomicUpdateCommand.cs
@@ -16,12 +16,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using System.Runtime.Serialization.Json;
 using System.IO;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace SolrNet.Commands
 {
@@ -75,40 +73,15 @@ namespace SolrNet.Commands
 
         private string GetAtomicUpdateJson()
         {
-            string json = "[{\"" + uniqueKey + "\":\"" + id + "\"";
+            string json = "[{" + JsonConvert.SerializeObject(uniqueKey) + ":" + JsonConvert.SerializeObject(id);
 
             foreach (var updateSpec in updateSpecs)
             {
-                json += ",\"" + updateSpec.Field + "\":{\"" + updateSpec.Type.ToString().ToLower() + "\":" + ParseValue(updateSpec.Value) + "}";
+                json += "," + JsonConvert.SerializeObject(updateSpec.Field) + ":{\"" + updateSpec.Type.ToString().ToLower() + "\":" + JsonConvert.SerializeObject(updateSpec.Value) + "}";
             }
 
             json += "}]";
             return json;
-        }
-
-        private string ParseValue(object value)
-        {
-            if (value is int)
-                return value.ToString();
-            if (value is string)
-                return "\"" + value + "\"";
-            if (value is string[])
-            {
-                string[] values = (string[])value;
-                string str = "[";
-                for(int i=0; i<values.Length; i++)
-                {
-                    str += "\"" + values[i] + "\"";
-                    if(i != values.Length - 1)
-                    {
-                        str += ","; // Add comma (except on the last value)
-                    }
-                }
-                str += "]";
-                return str;
-            }
-
-            throw new ArgumentNullException("Value for atomic update must be int, string or string[].");
         }
     }
 }

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -49,4 +49,7 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description
Issue #445 highlights a bug in the json serialization for AtomicUpdateCommand where special characters like `"` and `\n` are incorrectly serialized before being sent to solr. This changes `GetAtomicUpdateJson()` to use the Newtonsoft.Json package to handle the serialization. 

Additionally, the serialization change in this PR fixes another issue with `AtomicUpdateCommand`, preventing SolrNet from passing in null values of type `string` and `string[]` to solr. This is used for explicitly deleting a field in atomic updates.

> Set or replace the field value(s) with the specified value(s), or remove the values if 'null' or empty list is specified as the new value.

[Solr Documentation](https://lucene.apache.org/solr/guide/6_6/updating-parts-of-documents.html#UpdatingPartsofDocuments-AtomicUpdates)

### Testing

- All current AtomicUpdateCommandTests pass
- New passing serialization test for common escape characters
- New passing null value tests for null string and string[] values