### PR TITLE
Atomic Update Command Name Bugfix

### DIFF
--- a/SolrNet.Tests/AtomicUpdateCommandTests.cs
+++ b/SolrNet.Tests/AtomicUpdateCommandTests.cs
@@ -352,5 +352,22 @@ namespace SolrNet.Tests
             cmd.Execute(conn);
             Assert.Equal(1, conn.postStream.Calls);
         }
+
+        [Fact]
+        public void AtomicUpdateCommandNameInvariantCulture()
+        {
+            var conn = new Mocks.MSolrConnection();
+            conn.postStream += new MFunc<string, string, Stream, IEnumerable<KeyValuePair<string, string>>, string>((url, contentType, content, param) => {
+                string text = new StreamReader(content, Encoding.UTF8).ReadToEnd();
+                Assert.Equal("/update", url);
+                Assert.Equal("[{\"id\":\"0\",\"count\":{\"inc\":1}}]", text);
+                Console.WriteLine(text);
+                return null;
+            });
+            var updateSpecs = new AtomicUpdateSpec[] { new AtomicUpdateSpec("count", AtomicUpdateType.Inc, 1) };
+            var cmd = new AtomicUpdateCommand("id", "0", updateSpecs, null);
+            cmd.Execute(conn);
+            Assert.Equal(1, conn.postStream.Calls);
+        }
     }
 }

--- a/SolrNet/Commands/AtomicUpdateCommand.cs
+++ b/SolrNet/Commands/AtomicUpdateCommand.cs
@@ -77,7 +77,7 @@ namespace SolrNet.Commands
 
             foreach (var updateSpec in updateSpecs)
             {
-                json += "," + JsonConvert.SerializeObject(updateSpec.Field) + ":{\"" + updateSpec.Type.ToString().ToLower() + "\":" + JsonConvert.SerializeObject(updateSpec.Value) + "}";
+                json += "," + JsonConvert.SerializeObject(updateSpec.Field) + ":{\"" + updateSpec.Type.ToString().ToLowerInvariant() + "\":" + JsonConvert.SerializeObject(updateSpec.Value) + "}";
             }
 
             json += "}]";


### PR DESCRIPTION
Atomic Update Increment Command Name is produced as "ınc" in Turkish locale. It should be independent of current locale. The correct command should be "inc". 
The issue is described in #474 