### PR TITLE
Fix for AutoSolrConnection and very long requests

### DIFF
--- a/SolrNet.Tests/AutoSolrConnectionTests.cs
+++ b/SolrNet.Tests/AutoSolrConnectionTests.cs
@@ -90,7 +90,7 @@ namespace SolrNet.Tests
             var p = new Dictionary<string, string>();
             p["q"] = "*";
             p["rows"] = "1";
-            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => "a"));
+            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => Guid.NewGuid().ToString()));
             var conn = new AutoSolrConnection(solrURL);
             XDocument xdoc;
             using (var response = await conn.GetAsStreamAsync("/select/", p, default(CancellationToken)))
@@ -109,7 +109,7 @@ namespace SolrNet.Tests
             var p = new Dictionary<string, string>();
             p["q"] = "*";
             p["rows"] = "1";
-            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => "a"));
+            p["test"] = string.Join("", Enumerable.Range(0, 9000).Select(a => Guid.NewGuid().ToString()));
             var conn = new AutoSolrConnection(solrURL);
             XDocument xdoc;
             using (var response = await conn.GetAsStreamAsync("/select/", p, CancellationToken.None))


### PR DESCRIPTION
Currently AutoSolrConnection uses Uri.ToString().Length to figure out if a request is over the GET size limit, but on very long strings Uri.ToString will instead return a FormatException which isn't caught. This fix wraps the function in a Try Catch and removes the Query part and sends a POST request instead.