### PR TITLE
wt- and xml version-parameter fix in connection classes

### DIFF
--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -146,12 +146,20 @@ namespace SolrNet.Impl
             if (parameters != null)
                 param.AddRange(parameters);
 
-            param.Add(new KeyValuePair<string, string>("version", version));
-
             if (param.All(x => x.Key != "wt"))
             {
                 // only set wt=xml if wt wasn't already set by the caller
                 param.Add(new KeyValuePair<string, string>("wt", "xml"));
+            }
+
+            if (param.Single(x => x.Key == "wt").Value == "xml")
+            {
+                // only set version if wt is set to xml since version specifies the xml protocol version (see Solr docs)
+                // and only set version if it wasn't already set by the caller
+                if (param.All(x => x.Key != "version"))
+                {
+                    param.Add(new KeyValuePair<string, string>("version", version));
+                }
             }
 
             return string.Join("&", param.Select(kv => $"{WebUtility.UrlEncode(kv.Key)}={WebUtility.UrlEncode(kv.Value)}"));

--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -147,7 +147,12 @@ namespace SolrNet.Impl
                 param.AddRange(parameters);
 
             param.Add(new KeyValuePair<string, string>("version", version));
-            param.Add(new KeyValuePair<string, string>("wt", "xml"));
+
+            if (param.All(x => x.Key != "wt"))
+            {
+                // only set wt=xml if wt wasn't already set by the caller
+                param.Add(new KeyValuePair<string, string>("wt", "xml"));
+            }
 
             return string.Join("&", param.Select(kv => $"{WebUtility.UrlEncode(kv.Key)}={WebUtility.UrlEncode(kv.Value)}"));
 

--- a/SolrNet/Impl/SolrConnection.cs
+++ b/SolrNet/Impl/SolrConnection.cs
@@ -282,12 +282,20 @@ namespace SolrNet.Impl
             if (parameters != null)
                 param.AddRange(parameters);
 
-            param.Add(KV.Create("version", version));
-
             if (param.All(x => x.Key != "wt"))
             {
                 // only set wt=xml if wt wasn't already set by the caller
                 param.Add(KV.Create("wt", "xml"));
+            }
+
+            if (param.Single(x => x.Key == "wt").Value == "xml")
+            {
+                // only set version if wt is set to xml since version specifies the xml protocol version (see Solr docs)
+                // and only set version if it wasn't already set by the caller
+                if (param.All(x => x.Key != "version"))
+                {
+                    param.Add(KV.Create("version", version));
+                }
             }
 
             return string.Join("&", param


### PR DESCRIPTION
I use the SolrConnection.cs class directly for some features currently not supported by SolrNet (e.g. Suggester). While doing so, I run into the situation, that SolrNet sent requests like the following to Solr server:

http://...:8983/suggest?...&wt=json&wt=xml&version=2.2

I set the wt param to "json", but both xml and json were included in the request url. In addition the xml version was included.

I found out, that issue #508 and pr #509 already addressed the first issue but fixed it only in SolrConnection class (but not in SolrAutoConnection class).

This pr is about the following:
- only fallback to wt=xml if wt was not set by the caller also in AutoSolrConnection
- only set version if wt is set to xml since version specifies the xml protocol version (see Solr docs)

What I am not sure about:
- Is is correct, that the fix from pr #509 also should be applied in AutoSolrConnection class?
- Should the same logic also be applied in SolrPostConnection class (see line 65)? This is not included in this pull request.
- Should tests be modified or completed? (WithWtJson_Get() expects wt=json and version=2.2 and run through in my branch using my modifications but I didn't understand why.)