### PR TITLE
Fix for AutoSolrConnection throwing an ArgumentNullException 

### DIFF
--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -138,7 +138,8 @@ namespace SolrNet.Impl
             u.Query = GetQuery(getParameters);
 
             var sc = new StreamContent(content);
-            sc.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(contentType);
+            if(contentType != null)
+                sc.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(contentType);
 
             var response = await HttpClient.PostAsync(u.Uri, sc);
 


### PR DESCRIPTION
This happens when the contentType param is null. Solr is ok with this param not existing so it can choose the right extractor for you.

SolrConnection has this null check as well.