### PR TITLE
Use the response body from the failed post for the exception message…

### DIFF
--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -143,7 +143,7 @@ namespace SolrNet.Impl
             var response = await HttpClient.PostAsync(u.Uri, sc);
 
             if (!response.IsSuccessStatusCode)
-                throw new SolrConnectionException($"{response.StatusCode}: {response.ReasonPhrase}", null, u.Uri.ToString());
+                throw new SolrConnectionException(await response.Content.ReadAsStringAsync(), null, u.Uri.ToString());
 
             return await response.Content.ReadAsStreamAsync();
         }


### PR DESCRIPTION
… in AutoSolrConnection.

SolrConnection has this body when a SolrConnectionException is thrown.