### PR TITLE
System.ArgumentException when highlighting response contains duplicates (Solr 8.11.1)

### DIFF
--- a/SolrNet/Impl/ResponseParsers/HighlightingResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/HighlightingResponseParser.cs
@@ -51,7 +51,10 @@ namespace SolrNet.Impl.ResponseParsers {
             var docRefs = node.Elements("lst");
             foreach (var docRef in docRefs) {
                 var docRefKey = docRef.Attribute("name").Value;
-                highlights.Add(docRefKey, ParseHighlightingFields(docRef.Elements()));                    
+                if (!highlights.ContainsKey(docRefKey))
+                {
+                    highlights.Add(docRefKey, ParseHighlightingFields(docRef.Elements()));
+                }
             }
             return highlights;
         }


### PR DESCRIPTION
System.ArgumentException
  HResult=0x80070057
  Message=An item with the same key has already been added.
  Source=mscorlib
  StackTrace:
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at SolrNet.Impl.ResponseParsers.HighlightingResponseParser`1.ParseHighlighting(IEnumerable`1 results, XElement node) in C:\projects\SolrNet\Impl\ResponseParsers\HighlightingResponseParser.cs:line 54
   at SolrNet.Impl.ResponseParsers.HighlightingResponseParser`1.Parse(XDocument xml, SolrQueryResults`1 results) in C:\projects\SolrNet\Impl\ResponseParsers\HighlightingResponseParser.cs:line 40
   at SolrNet.Impl.ResponseParsers.HighlightingResponseParser`1.<>c__DisplayClass0_0.<Parse>b__0(SolrQueryResults`1 r) in C:\projects\SolrNet\Impl\ResponseParsers\HighlightingResponseParser.cs:line 32
   at SolrNet.Utils.F.<>c__DisplayClass1_0`1.<ToFunc>b__0(T x) in C:\projects\SolrNet\Utils\Unit.cs:line 29
   at SolrNet.SolrQueryResults`1.Switch[R](Func`2 query, Func`2 moreLikeThis) in C:\projects\SolrNet\SolrQueryResults.cs:line 95
   at SolrNet.Impl.AbstractSolrQueryResults`1.Switch(Action`1 query, Action`1 moreLikeThis) in C:\projects\SolrNet\Impl\AbstractSolrQueryResults.cs:line 88
   at SolrNet.Impl.ResponseParsers.HighlightingResponseParser`1.Parse(XDocument xml, AbstractSolrQueryResults`1 results) in C:\projects\SolrNet\Impl\ResponseParsers\HighlightingResponseParser.cs:line 32
   at SolrNet.Impl.ResponseParsers.AggregateResponseParser`1.Parse(XDocument xml, AbstractSolrQueryResults`1 results) in C:\projects\SolrNet\Impl\ResponseParsers\AggregateResponseParser.cs:line 16
   at SolrNet.Impl.ResponseParsers.DefaultResponseParser`1.Parse(XDocument xml, AbstractSolrQueryResults`1 results) in C:\projects\SolrNet\Impl\ResponseParsers\DefaultResponseParser.cs:line 31
   at SolrNet.Impl.SolrQueryExecuter`1.Execute(ISolrQuery q, QueryOptions options) in C:\projects\SolrNet\Impl\SolrQueryExecuter.cs:line 678
   at SolrNet.Impl.SolrBasicServer`1.Query(ISolrQuery query, QueryOptions options) in C:\projects\SolrNet\Impl\SolrBasicServer.cs:line 124
   at SolrNet.Impl.SolrServer`1.Query(String q, QueryOptions options) in C:\projects\SolrNet\Impl\SolrServer.cs:line 92
   ...

![exception](https://user-images.githubusercontent.com/1131048/150285509-875a9e54-e67c-40f4-9621-e2b01023fdc8.png)

![data](https://user-images.githubusercontent.com/1131048/150285518-c90704cc-efe2-4fee-850e-42370950a7c7.png)

