### PR TITLE
Add constructors to gain control over httpwebrequestfactories for synchronous operations

### DIFF
--- a/SolrNet/Impl/SolrConnection.cs
+++ b/SolrNet/Impl/SolrConnection.cs
@@ -51,12 +51,21 @@ namespace SolrNet.Impl
         /// Manages HTTP connection with Solr
         /// </summary>
         /// <param name="serverURL">URL to Solr</param>
-        public SolrConnection(string serverURL)
+        public SolrConnection(string serverURL) : this(serverURL, new HttpWebRequestFactory())
+        {
+        }
+
+        /// <summary>
+        /// Manages HTTP connection with Solr
+        /// </summary>
+        /// <param name="serverURL">URL to Solr</param>
+        /// <param name="httpWebRequestFactory">Request factory to be used in synchronous fallback connections</param>
+        public SolrConnection(string serverURL, IHttpWebRequestFactory httpWebRequestFactory)
         {
             ServerURL = serverURL;
             Timeout = -1;
             Cache = new NullCache();
-            HttpWebRequestFactory = new HttpWebRequestFactory();
+            HttpWebRequestFactory = httpWebRequestFactory;
         }
 
         /// <summary>

--- a/SolrNet/Impl/SolrPostConnection.cs
+++ b/SolrNet/Impl/SolrPostConnection.cs
@@ -25,11 +25,29 @@ namespace SolrNet.Impl
         /// </summary>
         public IHttpWebRequestFactory HttpWebRequestFactory { get; set; }
 
-        public PostSolrConnection(ISolrConnection conn, string serverUrl)
+        /// <summary>
+        /// Manages HTTP connection with Solr using HTTP POST.
+        /// 
+        /// Note that this constructor uses <see cref="HttpWebAdapters.HttpWebRequestFactory"/> and thus doesn't support basic authentication and such
+        /// Please use <see cref="PostSolrConnection(ISolrConnection, string, IHttpWebRequestFactory)"/>
+        /// </summary>
+        /// <param name="conn">SolrConnection instance to handle HTTP requests</param>
+        /// <param name="serverUrl">URL to Solr</param>
+        public PostSolrConnection(ISolrConnection conn, string serverUrl) : this(conn, serverUrl, new HttpWebRequestFactory())
+        {
+        }
+
+        /// <summary>
+        /// Manages HTTP connection with Solr using HTTP POST.
+        /// </summary>
+        /// <param name="conn">SolrConnection instance to handle HTTP requests</param>
+        /// <param name="serverUrl">URL to Solr</param>
+        /// <param name="httpWebRequestFactory">Request factory to be used in HTTP requests</param>
+        public PostSolrConnection(ISolrConnection conn, string serverUrl, IHttpWebRequestFactory httpWebRequestFactory)
         {
             this.conn = conn;
             this.serverUrl = serverUrl;
-            HttpWebRequestFactory = new HttpWebRequestFactory();
+            this.HttpWebRequestFactory = httpWebRequestFactory;
         }
 
         /// <summary>


### PR DESCRIPTION
Added constructors to various connection types so we can gain control over the usage of IHttpWebRequestFactory.

Asynchronous requests use HttpClient which is injected via constructors already.
For synchronous requests the connection types now hardcode the use of HttpWebRequestFactory, and thus don't support a custom implementation (or BasicAuthHttpWebRequestFactory in my use-case).