### PR TITLE
Fix integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ packages/*
 .idea
 *.swp
 solr_output.txt
+solr_output_auth.txt
 */TestResults/*

--- a/AutofacContrib.SolrNet.Tests/AutofacIntegrationFixture.cs
+++ b/AutofacContrib.SolrNet.Tests/AutofacIntegrationFixture.cs
@@ -55,8 +55,7 @@ namespace AutofacContrib.SolrNet.Tests {
             solr.Add(new Dictionary<string, object> {
                 {"id", "ababa"},
                 {"manu", "who knows"},
-                {"popularity", 55},
-                {"timestamp", DateTime.UtcNow},
+                {"popularity", 55}
             });
         }
     }

--- a/Castle.Facilities.SolrNetIntegration.Tests/CastleIntegrationFixture.cs
+++ b/Castle.Facilities.SolrNetIntegration.Tests/CastleIntegrationFixture.cs
@@ -59,8 +59,7 @@ namespace Castle.Facilities.SolrNetIntegration.Tests {
             solr.Add(new Dictionary<string, object> {
                 {"id", "ababa"},
                 {"manu", "who knows"},
-                {"popularity", 55},
-                {"timestamp", DateTime.UtcNow},
+                {"popularity", 55}
             });
         }
     }

--- a/LightInject.SolrNet.Tests/LightInject.SolrNet.Tests.csproj
+++ b/LightInject.SolrNet.Tests/LightInject.SolrNet.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LightInject" Version="6.4.1" />
+    <PackageReference Include="LightInject" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/LightInject.SolrNet.Tests/packages.lock.json
+++ b/LightInject.SolrNet.Tests/packages.lock.json
@@ -4,9 +4,27 @@
     ".NETCoreApp,Version=v5.0": {
       "LightInject": {
         "type": "Direct",
-        "requested": "[6.4.1, )",
-        "resolved": "6.4.1",
-        "contentHash": "PWmsA9RnMBlrTnZQIr0qZDWj/hmgbM6PcSWr31mLcH6vcrGFlGjcxouLCH/uMNC6Lmf8z84Eue1u4pu3WZUghA=="
+        "requested": "[4.1.1, )",
+        "resolved": "4.1.1",
+        "contentHash": "h7iB/TB2uYgOLkDZLrrHsleAg/IQu5vgA2vr9iw5AC0EZ6QYB28Zz7ObO/BFGPwc9O9BRqidjo430Vjhg4zOdw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
@@ -1185,7 +1203,7 @@
       "SolrNet.LightInject": {
         "type": "Project",
         "dependencies": {
-          "LightInject": "6.4.1",
+          "LightInject": "4.1.1",
           "SolrNet.Core": "1.0.20"
         }
       }

--- a/LightInject.SolrNet/LightInject.SolrNet.csproj
+++ b/LightInject.SolrNet/LightInject.SolrNet.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LightInject" Version="6.4.1" />
+    <PackageReference Include="LightInject" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LightInject.SolrNet/packages.lock.json
+++ b/LightInject.SolrNet/packages.lock.json
@@ -4,9 +4,27 @@
     ".NETStandard,Version=v2.0": {
       "LightInject": {
         "type": "Direct",
-        "requested": "[6.4.1, )",
-        "resolved": "6.4.1",
-        "contentHash": "PWmsA9RnMBlrTnZQIr0qZDWj/hmgbM6PcSWr31mLcH6vcrGFlGjcxouLCH/uMNC6Lmf8z84Eue1u4pu3WZUghA=="
+        "requested": "[4.1.1, )",
+        "resolved": "4.1.1",
+        "contentHash": "h7iB/TB2uYgOLkDZLrrHsleAg/IQu5vgA2vr9iw5AC0EZ6QYB28Zz7ObO/BFGPwc9O9BRqidjo430Vjhg4zOdw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
       },
       "NETStandard.Library": {
         "type": "Direct",
@@ -71,6 +89,23 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "2gBcbb3drMLgxlI0fBfxMA31ec6AEyYCHygGse4vxceJan8mRIWeKJ24BFzN7+bi/NFTgdIgufzb94LWO5EERQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
         }
       },
       "System.Collections.NonGeneric": {
@@ -148,6 +183,26 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "vDN1PoMZCkkdNjvZLql592oYJZgS7URcJzJ7bxeBgGtx5UtR5leNm49VmfHGqIffX4FKacHbI3H6UyNSHQknBg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Dynamic.Runtime": {

--- a/Ninject.Integration.SolrNet.Tests/NinjectIntegrationFixture.cs
+++ b/Ninject.Integration.SolrNet.Tests/NinjectIntegrationFixture.cs
@@ -33,7 +33,7 @@ namespace Ninject.Integration.SolrNet.Tests {
             var solrServers = new SolrServers {
                 new SolrServerElement {
                     Id = "default",
-                    Url = "http://localhost:8983/solr/techproducts/core0",
+                    Url = "http://localhost:8983/solr/core0",
                     DocumentType = typeof(Entity).AssemblyQualifiedName,
                 }
             };
@@ -49,12 +49,12 @@ namespace Ninject.Integration.SolrNet.Tests {
             var solrServers = new SolrServers {
                 new SolrServerElement {
                     Id = "main",
-                    Url = "http://localhost:8983/solr/techproducts/core0",
+                    Url = "http://localhost:8983/solr/core0",
                     DocumentType = typeof(Entity).AssemblyQualifiedName,
                 },
                 new SolrServerElement {
                     Id = "alt",
-                    Url = "http://localhost:8983/solr/techproducts/core1",
+                    Url = "http://localhost:8983/solr/core1",
                     DocumentType = typeof(Entity2).AssemblyQualifiedName,
                 }
             };
@@ -73,12 +73,12 @@ namespace Ninject.Integration.SolrNet.Tests {
             var solrServers = new SolrServers {
                 new SolrServerElement {
                     Id = "core-0",
-                    Url = "http://localhost:8983/solr/techproducts/core0",
+                    Url = "http://localhost:8983/solr/core0",
                     DocumentType = typeof(Entity).AssemblyQualifiedName,
                 },
                 new SolrServerElement {
                     Id = "core-1",
-                    Url = "http://localhost:8983/solr/techproducts/core1",
+                    Url = "http://localhost:8983/solr/core1",
                     DocumentType = typeof(Entity2).AssemblyQualifiedName,
                 }
             };

--- a/SimpleInjector.SolrNet.Tests/SimpleInjectorIntegrationFixture.cs
+++ b/SimpleInjector.SolrNet.Tests/SimpleInjectorIntegrationFixture.cs
@@ -18,7 +18,7 @@ namespace SimpleInjector.SolrNet.Tests
             Container = new Container();
 
             // collection needs to exist
-            Container.AddSolrNet("http://localhost:8983/solr/techproducts/FilesCollection");
+            Container.AddSolrNet("http://localhost:8983/solr/entity1");
         }
         
         [Fact]

--- a/SolrNet.Cloud.Tests/packages.lock.json
+++ b/SolrNet.Cloud.Tests/packages.lock.json
@@ -108,6 +108,29 @@
           "Microsoft.NETCore.Platforms": "1.0.1"
         }
       },
+      "LightInject": {
+        "type": "Transitive",
+        "resolved": "4.1.1",
+        "contentHash": "h7iB/TB2uYgOLkDZLrrHsleAg/IQu5vgA2vr9iw5AC0EZ6QYB28Zz7ObO/BFGPwc9O9BRqidjo430Vjhg4zOdw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
         "resolved": "1.1.0",
@@ -2024,6 +2047,13 @@
           "Newtonsoft.Json": "10.0.3"
         }
       },
+      "SolrNet.LightInject": {
+        "type": "Project",
+        "dependencies": {
+          "LightInject": "4.1.1",
+          "SolrNet.Core": "1.0.20"
+        }
+      },
       "solrnet.tests.common": {
         "type": "Project",
         "dependencies": {
@@ -2040,6 +2070,7 @@
           "Castle.Core": "4.2.1",
           "Castle.Windsor": "4.1.0",
           "CommonServiceLocator": "2.0.2",
+          "LightInject": "4.1.1",
           "Microsoft.NET.Test.Sdk": "16.11.0",
           "SolrNet": "1.1.0",
           "SolrNet.Cloud": "1.1.0",
@@ -2047,6 +2078,7 @@
           "SolrNet.Cloud.Unity": "1.1.0",
           "SolrNet.Core": "1.1.0",
           "SolrNet.Tests.Common": "1.1.0",
+          "SolrNet.LightInject": "1.1.0",
           "System.Configuration.ConfigurationManager": "5.0.0",
           "xunit": "2.4.1",
           "xunit.runner.visualstudio": "2.4.1"

--- a/SolrNet.Tests.Integration/IntegrationFixtureTestAuthentication.cs
+++ b/SolrNet.Tests.Integration/IntegrationFixtureTestAuthentication.cs
@@ -1,0 +1,89 @@
+﻿#region license
+// Copyright (c) 2007-2010 Mauricio Scheffer
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Text;
+using Xunit;
+using System.Threading.Tasks;
+using HttpWebAdapters;
+using SolrNet.Exceptions;
+using Xunit.Abstractions;
+
+namespace SolrNet.Tests.Integration
+{
+    [Trait("Category", "Integration")]
+    [TestCaseOrderer(MethodDefTestCaseOrderer.Type, MethodDefTestCaseOrderer.Assembly)]
+    public class IntegrationFixtureTestAuthentication
+    {
+        //private readonly ITestOutputHelper testOutputHelper;
+        //private readonly IServiceProvider defaultServiceProviderAuth_WithSyncAuth;
+        //private readonly IServiceProvider defaultServiceProviderAuth_WithSyncAndAsyncAuth;
+        //private readonly IServiceProvider defaultServiceProviderAuth_WithoutAuth;     
+
+        //public IntegrationFixtureTestAuthentication(ITestOutputHelper testOutputHelper)
+        //{
+        //    var sc = new ServiceCollection();
+        //    this.defaultServiceProviderAuth_WithSyncAuth.AddSolrNet("http://localhost:8984/solr/techproducts",
+        //        null,
+        //        () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
+
+        //    this.defaultServiceProviderAuth_WithSyncAndAsyncAuth = new ServiceContainer();
+        //    this.defaultServiceProviderAuth_WithSyncAndAsyncAuth.AddSolrNet("http://localhost:8984/solr/techproducts",
+        //        (options) => options.HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"solr:SolrRocks"))),
+        //        () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
+
+
+        //    this.defaultServiceProviderAuth_WithoutAuth = new ServiceContainer();
+        //    this.defaultServiceProviderAuth_WithoutAuth.AddSolrNet("http://localhost:8984/solr/techproducts");     
+        //}
+
+        //[Fact]
+        //public void Test_SolrWithAuth_ServiceContainerSyncAuth_Ping()
+        //{
+        //    var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
+        //    solr.Ping();
+        //    testOutputHelper.WriteLine(solr.Query(SolrQuery.All).Count.ToString());
+        //}
+
+        //[Fact]
+        //public void Test_SolrWithAuth_ServiceContainerASyncAuth_Ping()
+        //{
+        //    var solr = defaultServiceProviderAuth_WithSyncAndAsyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
+        //    Task.Run(async () => await solr.PingAsync());
+        //    testOutputHelper.WriteLine(Task.Run(async () => await solr.QueryAsync(SolrQuery.All)).Result.Count.ToString());
+        //}
+
+        //[Fact]
+        //public void Test_SolrWithAuth_ServiceContainerSyncAuth_AsyncPingFails()
+        //{
+        //    var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
+        //    var ex = Assert.ThrowsAsync<SolrConnectionException>(async () => {
+        //        await solr.PingAsync();
+        //    });
+        //    Assert.Contains("401", ex.Result.Message.ToLower());
+        //}
+
+        //[Fact]
+        //public void Test_SolrWithAuth_ServiceContainerWithoutAuth_PingFails()
+        //{
+        //    var solr = defaultServiceProviderAuth_WithoutAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
+        //    var ex = Assert.Throws<SolrConnectionException>(() => {
+        //        solr.Ping();
+        //    });
+        //    Assert.Contains("401", ex.Message.ToLower());
+        //}
+    }
+}

--- a/SolrNet.Tests.Integration/IntegrationFixtureTestAuthentication.cs
+++ b/SolrNet.Tests.Integration/IntegrationFixtureTestAuthentication.cs
@@ -19,71 +19,73 @@ using System.Text;
 using Xunit;
 using System.Threading.Tasks;
 using HttpWebAdapters;
+using LightInject;
 using SolrNet.Exceptions;
+using SolrNet.Tests.Integration.Sample;
 using Xunit.Abstractions;
 
 namespace SolrNet.Tests.Integration
 {
     [Trait("Category", "Integration")]
-    [TestCaseOrderer(MethodDefTestCaseOrderer.Type, MethodDefTestCaseOrderer.Assembly)]
     public class IntegrationFixtureTestAuthentication
     {
-        //private readonly ITestOutputHelper testOutputHelper;
-        //private readonly IServiceProvider defaultServiceProviderAuth_WithSyncAuth;
-        //private readonly IServiceProvider defaultServiceProviderAuth_WithSyncAndAsyncAuth;
-        //private readonly IServiceProvider defaultServiceProviderAuth_WithoutAuth;     
+        private readonly IServiceContainer defaultServiceProviderAuth_WithSyncAuth;
+        private readonly IServiceContainer defaultServiceProviderAuth_WithSyncAndAsyncAuth;
+        private readonly IServiceContainer defaultServiceProviderAuth_WithoutAuth;
 
-        //public IntegrationFixtureTestAuthentication(ITestOutputHelper testOutputHelper)
-        //{
-        //    var sc = new ServiceCollection();
-        //    this.defaultServiceProviderAuth_WithSyncAuth.AddSolrNet("http://localhost:8984/solr/techproducts",
-        //        null,
-        //        () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
+        public IntegrationFixtureTestAuthentication()
+        {
+            this.defaultServiceProviderAuth_WithSyncAuth = new ServiceContainer();
+            this.defaultServiceProviderAuth_WithSyncAuth.AddSolrNet<Product>("http://localhost:8984/solr/techproducts",
+                null,
+                () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
 
-        //    this.defaultServiceProviderAuth_WithSyncAndAsyncAuth = new ServiceContainer();
-        //    this.defaultServiceProviderAuth_WithSyncAndAsyncAuth.AddSolrNet("http://localhost:8984/solr/techproducts",
-        //        (options) => options.HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"solr:SolrRocks"))),
-        //        () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
+            this.defaultServiceProviderAuth_WithSyncAndAsyncAuth = new ServiceContainer();
+            this.defaultServiceProviderAuth_WithSyncAndAsyncAuth.AddSolrNet<Product>("http://localhost:8984/solr/techproducts",
+                (options) => options.HttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"solr:SolrRocks"))),
+                () => new BasicAuthHttpWebRequestFactory("solr", "SolrRocks"));
 
 
-        //    this.defaultServiceProviderAuth_WithoutAuth = new ServiceContainer();
-        //    this.defaultServiceProviderAuth_WithoutAuth.AddSolrNet("http://localhost:8984/solr/techproducts");     
-        //}
+            this.defaultServiceProviderAuth_WithoutAuth = new ServiceContainer();
+            this.defaultServiceProviderAuth_WithoutAuth.AddSolrNet<Product>("http://localhost:8984/solr/techproducts");
+        }
 
-        //[Fact]
-        //public void Test_SolrWithAuth_ServiceContainerSyncAuth_Ping()
-        //{
-        //    var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
-        //    solr.Ping();
-        //    testOutputHelper.WriteLine(solr.Query(SolrQuery.All).Count.ToString());
-        //}
+        [Fact]
+        public void Test_SolrWithAuth_ServiceContainerSyncAuth_Ping()
+        {
+            var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<Product>>();
+            solr.Ping();
+            Assert.InRange(solr.Query(SolrQuery.All).Count, 1, int.MaxValue);
+        }
 
-        //[Fact]
-        //public void Test_SolrWithAuth_ServiceContainerASyncAuth_Ping()
-        //{
-        //    var solr = defaultServiceProviderAuth_WithSyncAndAsyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
-        //    Task.Run(async () => await solr.PingAsync());
-        //    testOutputHelper.WriteLine(Task.Run(async () => await solr.QueryAsync(SolrQuery.All)).Result.Count.ToString());
-        //}
+        [Fact]
+        public void Test_SolrWithAuth_ServiceContainerASyncAuth_Ping()
+        {
+            var solr = defaultServiceProviderAuth_WithSyncAndAsyncAuth.GetInstance<ISolrOperations<Product>>();
+            Task.Run(async () => await solr.PingAsync());
+            Assert.InRange(Task.Run(async () => await solr.QueryAsync(SolrQuery.All)).Result.Count, 1, int.MaxValue);
+        }
 
-        //[Fact]
-        //public void Test_SolrWithAuth_ServiceContainerSyncAuth_AsyncPingFails()
-        //{
-        //    var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
-        //    var ex = Assert.ThrowsAsync<SolrConnectionException>(async () => {
-        //        await solr.PingAsync();
-        //    });
-        //    Assert.Contains("401", ex.Result.Message.ToLower());
-        //}
+        [Fact]
+        public void Test_SolrWithAuth_ServiceContainerSyncAuth_AsyncPingFails()
+        {
+            var solr = defaultServiceProviderAuth_WithSyncAuth.GetInstance<ISolrOperations<Product>>();
+            var ex = Assert.ThrowsAsync<SolrConnectionException>(async () =>
+            {
+                await solr.PingAsync();
+            });
+            Assert.Contains("401", ex.Result.Message.ToLower());
+        }
 
-        //[Fact]
-        //public void Test_SolrWithAuth_ServiceContainerWithoutAuth_PingFails()
-        //{
-        //    var solr = defaultServiceProviderAuth_WithoutAuth.GetInstance<ISolrOperations<LightInjectFixture.Entity>>();
-        //    var ex = Assert.Throws<SolrConnectionException>(() => {
-        //        solr.Ping();
-        //    });
-        //    Assert.Contains("401", ex.Message.ToLower());
-        //}
+        [Fact]
+        public void Test_SolrWithAuth_ServiceContainerWithoutAuth_PingFails()
+        {
+            var solr = defaultServiceProviderAuth_WithoutAuth.GetInstance<ISolrOperations<Product>>();
+            var ex = Assert.Throws<SolrConnectionException>(() =>
+            {
+                solr.Ping();
+            });
+            Assert.Contains("401", ex.Message.ToLower());
+        }
     }
 }

--- a/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
+++ b/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="CommonServiceLocator" Version="2.0.2" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Castle.Windsor" Version="4.1.0" />
-    <PackageReference Include="LightInject" Version="6.4.1" />
+    <PackageReference Include="LightInject" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
+++ b/SolrNet.Tests.Integration/SolrNet.Tests.Integration.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="CommonServiceLocator" Version="2.0.2" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
     <PackageReference Include="Castle.Windsor" Version="4.1.0" />
+    <PackageReference Include="LightInject" Version="6.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -14,6 +15,7 @@
  
   <ItemGroup>
     <ProjectReference Include="..\CommonServiceLocator.SolrNet.Cloud\CommonServiceLocator.SolrNet.Cloud.csproj" />
+    <ProjectReference Include="..\LightInject.SolrNet\LightInject.SolrNet.csproj" />
     <ProjectReference Include="..\SolrNet.Cloud\SolrNet.Cloud.csproj" />
     <ProjectReference Include="..\CommonServiceLocator.SolrNet\CommonServiceLocator.SolrNet.csproj" />
     <ProjectReference Include="..\SolrNet.Tests.Common\SolrNet.Tests.Common.csproj" />

--- a/SolrNet.Tests.Integration/packages.lock.json
+++ b/SolrNet.Tests.Integration/packages.lock.json
@@ -43,6 +43,30 @@
           "Microsoft.NETCore.App": "1.0.5"
         }
       },
+      "LightInject": {
+        "type": "Direct",
+        "requested": "[4.1.1, )",
+        "resolved": "4.1.1",
+        "contentHash": "h7iB/TB2uYgOLkDZLrrHsleAg/IQu5vgA2vr9iw5AC0EZ6QYB28Zz7ObO/BFGPwc9O9BRqidjo430Vjhg4zOdw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[16.11.0, )",
@@ -2029,6 +2053,13 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "10.0.3"
+        }
+      },
+      "SolrNet.LightInject": {
+        "type": "Project",
+        "dependencies": {
+          "LightInject": "4.1.1",
+          "SolrNet.Core": "1.0.20"
         }
       },
       "solrnet.tests.common": {

--- a/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
+++ b/StructureMap.SolrNetIntegration.Tests/StructureMapIntegrationFixture.cs
@@ -25,9 +25,9 @@ namespace StructureMap.SolrNetIntegration.Tests {
             this.testOutputHelper = testOutputHelper;
             var servers = new List<SolrServer>
             {
-                new SolrServer ("entity","http://localhost:8983/solr/techproducts/collection1", "StructureMap.SolrNetIntegration.Tests.Entity, StructureMap.SolrNetIntegration.Tests"),
-                new SolrServer ("entity2","http://localhost:8983/solr/techproducts/core0", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests"),
-                new SolrServer ("entity3","http://localhost:8983/solr/techproducts/core1", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests")
+                new SolrServer ("entity","http://localhost:8983/solr/entity1", "StructureMap.SolrNetIntegration.Tests.Entity, StructureMap.SolrNetIntegration.Tests"),
+                new SolrServer ("entity2","http://localhost:8983/solr/core0", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests"),
+                new SolrServer ("entity3","http://localhost:8983/solr/core1", "StructureMap.SolrNetIntegration.Tests.Entity2, StructureMap.SolrNetIntegration.Tests")
             };
             Container = new Container(c => c.IncludeRegistry(SolrNetRegistry.Create(servers)));
         }
@@ -47,7 +47,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
                 new SolrServerElement {
                     Id = "entity1dict",
                     DocumentType = typeof(Dictionary<string, object>).AssemblyQualifiedName,
-                    Url = "http://localhost:8983/solr/techproducts/core1",
+                    Url = "http://localhost:8983/solr/core1",
                 }
             };
 
@@ -71,7 +71,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
                 new SolrServerElement {
                     Id = "entity1dict",
                     DocumentType = typeof(Dictionary<string, object>).AssemblyQualifiedName,
-                    Url = "http://localhost:8983/solr/techproducts/core1",
+                    Url = "http://localhost:8983/solr/core1",
                 }
             };
 
@@ -83,8 +83,7 @@ namespace StructureMap.SolrNetIntegration.Tests {
             {
                 {"id", "ababa"},
                 {"manu", "who knows"},
-                {"popularity", 55},
-                {"timestamp", DateTime.UtcNow},
+                {"popularity", 55}
             });
         }
     }

--- a/Unity.SolrNetIntegration.Tests/UnityIntegrationFixture.cs
+++ b/Unity.SolrNetIntegration.Tests/UnityIntegrationFixture.cs
@@ -39,8 +39,9 @@ namespace Unity.SolrNetIntegration.Tests {
         [Fact]
         public void Ping_And_Query()
         {
-            using (var container = UnityFixture.SetupContainer())
+            using (var container = new UnityContainer())
             {
+                new SolrNetContainerConfiguration().ConfigureContainer(TestServers, container);
                 var solr = container.Resolve<ISolrOperations<Entity>>();
                 solr.Ping();
                 testOutputHelper.WriteLine(solr.Query(SolrQuery.All).Count.ToString());

--- a/Unity.SolrNetIntegration.Tests/UnityIntegrationFixture.cs
+++ b/Unity.SolrNetIntegration.Tests/UnityIntegrationFixture.cs
@@ -17,17 +17,17 @@ namespace Unity.SolrNetIntegration.Tests {
             new SolrServerElement {
                 Id = "entity",
                 DocumentType = typeof (Entity).AssemblyQualifiedName,
-                Url = "http://localhost:8983/solr/techproducts/core0",
+                Url = "http://localhost:8983/solr/core0",
             },
             new SolrServerElement {
                 Id = "entity2Dict",
                 DocumentType = typeof (Dictionary<string, object>).AssemblyQualifiedName,
-                Url = "http://localhost:8983/solr/techproducts/core1",
+                Url = "http://localhost:8983/solr/core1",
             },
             new SolrServerElement {
                 Id = "entity2",
                 DocumentType = typeof (Entity2).AssemblyQualifiedName,
-                Url = "http://localhost:8983/solr/techproducts/entity2",
+                Url = "http://localhost:8983/solr/entity2",
             },
         };
 
@@ -71,8 +71,7 @@ namespace Unity.SolrNetIntegration.Tests {
                 solr.Add(new Dictionary<string, object> {
                     {"id", "5"},
                     {"manu", "who knows"},
-                    {"popularity", 55},
-                    {"timestamp", DateTime.UtcNow},
+                    {"popularity", 55}
                 });
             }
         }

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -95,10 +95,6 @@ create_solr_auth() {
   echo -e "\n\rSetting up Solr_BasicAuth collection and documents..."
   
   setupSolrCore techproducts solr_cloud_auth 8984
-  setupSolrCore core0 solr_cloud_auth 8984
-  setupSolrCore core1 solr_cloud_auth 8984
-  setupSolrCore entity1 solr_cloud_auth 8984
-  setupSolrCore entity2 solr_cloud_auth 8984
   
   # enable basic auth after setup of collections has completed
   echo -e "\n\rSetting up Zookeeper in Solr_BasicAuth..." 

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -101,7 +101,7 @@ create_solr_auth() {
   setupSolrCore entity2 solr_cloud_auth 8984
   
   # enable basic auth after setup of collections has completed
-  echo -e "\n\rSettings up Zookeeper in Solr_BasicAuth..." 
+  echo -e "\n\rSetting up Zookeeper in Solr_BasicAuth..." 
   if [ "${SOLR_VERSION}" = "5.5.5" ]; then
 	docker exec solr_cloud_auth server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:9983 -cmd putfile /security.json /security.json
   else

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -8,19 +8,35 @@ run_tests() {
   local output="$2"
 
   echo -e "\n\rRunning integration tests..."
-  dotnet test SolrNet.Tests.Integration --filter 'Category=Integration' --logger html 1>$output 2>$output
+  dotnet test --filter 'Category=Integration&FullyQualifiedName!~Cloud' --logger html 1>$output 2>$output
   ret=$?
 
   if [ -n "$stop" ]; then
     echo -e "\n\rStopping Solr..."
-    docker stop solr_cloud
+	docker stop solr_cloud
+	docker stop solr_cloud_auth
   fi
   return $ret
 }
 
-create_solr() {
-  local next="$1"
+setupSolrCore() {
+  local coreName="$1"
+  local dockerContainerName="$2"
+  local solrPort="$3"
+  
+  docker exec $dockerContainerName solr create_collection -c $coreName -d sample_techproducts_configs 1>/dev/null 2>/dev/null
+  docker exec $dockerContainerName post -c $coreName 'example/exampledocs/' 1>/dev/null 2>/dev/null
 
+  curl -s -X POST -H 'Content-type:application/json' -d '{
+	"update-requesthandler": {
+	  "name": "/select",
+	  "class": "solr.SearchHandler",
+	  "last-components": ["spellcheck"]
+	}
+  }' http://localhost:$solrPort/solr/$coreName/config >/dev/null
+}
+
+create_solr() {
   echo -e "\n\rWaiting for Solr to start..."
   until docker container inspect solr_cloud 1>/dev/null 2>/dev/null; do
     sleep 0.5
@@ -30,30 +46,89 @@ create_solr() {
   done
 
   echo -e "\n\rSetting up Solr collection and documents..."
-  docker exec solr_cloud solr create_collection -c techproducts -d sample_techproducts_configs 1>/dev/null 2>/dev/null
-  docker exec solr_cloud post -c techproducts 'example/exampledocs/' 1>/dev/null 2>/dev/null
-
-  curl -s -X POST -H 'Content-type:application/json' -d '{
-    "update-requesthandler": {
-      "name": "/select",
-      "class": "solr.SearchHandler",
-      "last-components": ["spellcheck"]
-    }
-  }' http://localhost:8983/solr/techproducts/config >/dev/null
+  
+  setupSolrCore techproducts solr_cloud 8983
+  setupSolrCore core0 solr_cloud 8983
+  setupSolrCore core1 solr_cloud 8983
+  setupSolrCore entity1 solr_cloud 8983
+  setupSolrCore entity2 solr_cloud 8983
   
   echo -e "\n\rSolr available at http://localhost:8983\n\r"
 
   set -x
-  $next
+}
+
+create_solr_auth() {
+  local next="$1"
+
+  echo -e "\n\rWaiting for Solr_BasicAuth to start..."
+  until docker container inspect solr_cloud_auth 1>/dev/null 2>/dev/null; do
+    sleep 0.5
+  done
+  until curl -s http://localhost:8984 1>/dev/null 2>/dev/null; do
+    sleep 0.5
+  done
+  
+  echo -e "\n\rPreparing Solr_BasicAuth auth..."
+  
+  # output default (official Solr documentation) security.json to working directory
+	echo '{
+		"authentication":{ 
+		"blockUnknown": true, 
+		"class":"solr.BasicAuthPlugin",
+		"credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="}, 
+		"realm":"My Solr users", 
+		"forwardCredentials": false 
+		},
+		"authorization":{
+		"class":"solr.RuleBasedAuthorizationPlugin",
+		"permissions":[{"name":"security-edit",
+			"role":"admin"}], 
+		"user-role":{"solr":"admin"} 
+		}
+	}' > security.json
+		
+  # apply security.json to solr server
+  authcontainerId=$(docker inspect -f '{{.Id}}' solr_cloud_auth)
+  docker cp security.json $authcontainerId:/security.json
+
+  echo -e "\n\rSetting up Solr_BasicAuth collection and documents..."
+  
+  setupSolrCore techproducts solr_cloud_auth 8984
+  setupSolrCore core0 solr_cloud_auth 8984
+  setupSolrCore core1 solr_cloud_auth 8984
+  setupSolrCore entity1 solr_cloud_auth 8984
+  setupSolrCore entity2 solr_cloud_auth 8984
+  
+  # enable basic auth after setup of collections has completed
+  echo -e "\n\rSettings up Zookeeper in Solr_BasicAuth..." 
+  if [ "${SOLR_VERSION}" = "5.5.5" ]; then
+	docker exec solr_cloud_auth server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:9983 -cmd putfile /security.json /security.json
+  else
+	# docker 6+
+	docker exec solr_cloud_auth bin/solr zk cp file:/security.json zk:/security.json -z localhost:9983
+  fi
+  
+  echo -e "\n\rSolr_BasicAuth available at http://localhost:8984\n\r"
+
+  set -x
 }
 
 output=$(mktemp)
 trap "rm $output" EXIT
 
-create_solr "run_tests stop $output" &
-# create_solr "true" &
-tests=$!
+# start docker run jobs in background
+docker run --rm -p 8983:8983 --name solr_cloud solr:$SOLR_VERSION solr start -cloud -f >solr_output.txt &
+docker run --rm -p 8984:8983 --name solr_cloud_auth solr:$SOLR_VERSION solr start -cloud -f >solr_output_auth.txt  &
 
-docker run --rm -p 8983:8983 --name solr_cloud solr:$SOLR_VERSION solr start -cloud -f >solr_output.txt
+for i in create_solr create_solr_auth; do
+	"$i" & pids+=($!)
+done
+wait "${pids[@]}"
+
+run_tests stop $output
+testRunner=$?
+
 cat $output
-wait $tests
+
+exit $testRunner


### PR DESCRIPTION
Updated integration_tests.sh;
- Enabled execution of all integration tests
- Disabled execution of cloud integration tests
- Added another docker instance that has basic auth enabled
- Added multiple collections/cores, just to the default docker instance, required by various integration tests

Solution;
- Fixed failing integration tests
- Added integration tests to SolrNet.Tests to verify if basic auth is working, for both sync and async requests
- Lowered LightInject package version