### PR TITLE
Support client certificates with SolrNet.Cloud. Fixes #591

### DIFF
--- a/SolrNet.Cloud/ClientCertificateSolrOperationsProvider.cs
+++ b/SolrNet.Cloud/ClientCertificateSolrOperationsProvider.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using HttpWebAdapters;
+
+namespace SolrNet.Cloud
+{
+    /// <summary>
+    /// For using client certificates with Solr.Cloud
+    /// </summary>
+    public class ClientCertificateSolrOperationsProvider : ISolrOperationsProvider
+    {
+        private readonly IHttpWebRequestFactory _requestFactory;
+        private readonly int _timeOutSeconds;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="requestFactory">The request factory</param>
+        /// <param name="timeOutSeconds">the timeout in seconds</param>
+        public ClientCertificateSolrOperationsProvider(IHttpWebRequestFactory requestFactory, int timeOutSeconds)
+        {
+            _requestFactory = requestFactory;
+            _timeOutSeconds = timeOutSeconds;
+        }
+
+
+        public ISolrBasicOperations<T> GetBasicOperations<T>(string url, bool isPostConnection = false)
+        {
+            var connection = new Impl.SolrConnection(url);
+            connection.HttpWebRequestFactory = _requestFactory;
+            connection.Timeout = (int)TimeSpan.FromSeconds(_timeOutSeconds).TotalMilliseconds;
+
+            if (!isPostConnection)
+            {
+                return SolrNet.GetBasicServer<T>(connection);
+            }
+            else
+            {
+                var postConnection = new Impl.PostSolrConnection(connection, url);
+                postConnection.HttpWebRequestFactory = _requestFactory;
+                return SolrNet.GetBasicServer<T>(postConnection);
+            }
+        }
+
+
+
+        public ISolrOperations<T> GetOperations<T>(string url, bool isPostConnection = false)
+        {
+            var connection = new Impl.SolrConnection(url);
+            connection.HttpWebRequestFactory = _requestFactory;
+            connection.Timeout = (int)TimeSpan.FromSeconds(_timeOutSeconds).TotalMilliseconds;
+
+            if (!isPostConnection)
+            {
+                return SolrNet.GetServer<T>(connection);
+            }
+            else
+            {
+                var postConnection = new Impl.PostSolrConnection(connection, url);
+                postConnection.HttpWebRequestFactory = _requestFactory;
+                return SolrNet.GetServer<T>(postConnection);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support client certificates with SolrNet.Cloud. Fixes #591.

Usage:

            var cert = LoadCertificate(certificatePath, certificatePass);
            var requestFactory = cert is null
                ? new HttpWebRequestFactory() as IHttpWebRequestFactory
                : new ClientCertificateHttpWebRequestFactory(cert);

            var cloudStateProvider = new SolrNet.Cloud.ZooKeeperClient.SolrCloudStateProvider(zkConnectionString, zooKeeperTimeoutMs: timeoutSeconds * 1000);
            SolrNet.Cloud.Startup.InitAsync<T>(
                cloudStateProvider: cloudStateProvider,
                collectionName: collectionName,
                isPostConnection: true,
                solrOperationsProvider: new ClientCertificateSolrOperationsProvider(requestFactory, timeoutSeconds))
                    .ConfigureAwait(false)
                    .GetAwaiter()
                    .GetResult();


Also added a new method for resetting the DI, in case the previous initialization has failed:


            SolrNet.Cloud.Startup.Reset();