### PR TITLE
Added missing SolrCoreAdmin and SolrStatusResponseParser

### DIFF
--- a/Microsoft.DependencyInjection.SolrNet/ServiceCollectionExtensions.cs
+++ b/Microsoft.DependencyInjection.SolrNet/ServiceCollectionExtensions.cs
@@ -118,6 +118,7 @@ namespace SolrNet
             services.AddTransient<ISolrFacetQuerySerializer, DefaultFacetQuerySerializer>();
             services.AddTransient(typeof(ISolrAbstractResponseParser<>), typeof(DefaultResponseParser<>));
             services.AddTransient<ISolrHeaderResponseParser, HeaderResponseParser<string>>();
+            services.AddTransient<ISolrStatusResponseParser, SolrStatusResponseParser>();
             services.AddTransient<ISolrExtractResponseParser, ExtractResponseParser>();
             foreach (var p in new[] {
                 typeof(MappedPropertiesIsInSolrSchemaRule),
@@ -129,6 +130,7 @@ namespace SolrNet
             services.AddTransient(typeof(ISolrMoreLikeThisHandlerQueryResultsParser<>), typeof(SolrMoreLikeThisHandlerQueryResultsParser<>));
             services.AddTransient(typeof(ISolrDocumentSerializer<>), typeof(SolrDocumentSerializer<>));
             services.AddTransient<ISolrDocumentSerializer<Dictionary<string, object>>, SolrDictionarySerializer>();
+            services.AddTransient<ISolrCoreAdmin, SolrCoreAdmin>();
 
             services.AddTransient<ISolrSchemaParser, SolrSchemaParser>();
             services.AddTransient<ISolrDIHStatusParser, SolrDIHStatusParser>();


### PR DESCRIPTION
The current Microsoft DI builder doesn't include SolrCoreAdmin and SolrStatusResponseParser. This means with just the normal DI you can't get SOLR status and need additional registrations see below:

![image](https://user-images.githubusercontent.com/3377341/221836659-fef40911-c74b-41a4-96f9-15c9ea9dba0b.png)