### PR TITLE
AutoSolrConnection: Add required parameter for POST requests

### DIFF
--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -134,7 +134,7 @@ namespace SolrNet.Impl
                 u.Query = null;
                 var postParameters = GetPostParameters(parameters);
                 DiagnosticsUtil.EnrichCurrentActivity("POST", u.Uri);
-                response = await HttpClient.PostAsync(u.Uri, new FormUrlEncodedContent(parameters), cancellationToken);
+                response = await HttpClient.PostAsync(u.Uri, new FormUrlEncodedContent(postParameters), cancellationToken);
             }
             else
             {

--- a/SolrNet/Impl/AutoSolrConnection.cs
+++ b/SolrNet/Impl/AutoSolrConnection.cs
@@ -132,6 +132,7 @@ namespace SolrNet.Impl
             if (UriValidator.UriLength(u) > MaxUriLength)
             {
                 u.Query = null;
+                var postParameters = GetPostParameters(parameters);
                 DiagnosticsUtil.EnrichCurrentActivity("POST", u.Uri);
                 response = await HttpClient.PostAsync(u.Uri, new FormUrlEncodedContent(parameters), cancellationToken);
             }
@@ -223,6 +224,22 @@ namespace SolrNet.Impl
             DiagnosticsUtil.EnrichCurrentActivity(param);
             
             return string.Join("&", param.Select(kv => $"{WebUtility.UrlEncode(kv.Key)}={WebUtility.UrlEncode(kv.Value)}"));
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> GetPostParameters(IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            var param = new List<KeyValuePair<string, string>>();
+            if (parameters != null)
+                param.AddRange(parameters);
+
+            if (!param.Exists(param => param.Key == "version"))
+                param.Add(new KeyValuePair<string, string>("version", version));
+
+            if (!param.Exists(param => param.Key == "wt"))
+                param.Add(new KeyValuePair<string, string>("wt", "xml"));
+
+            return param;
+
         }
 
         #region IDisposable Support


### PR DESCRIPTION
AutoSolrConnection: Construct the parameter for POST requests ensuring required parameters like "version" and "wt" are included.

This PR solves an issue when the request is sent using a POST request instead of GET.
The **wt** parameter is omitted, hence the result comes back in JSON instead of XML.

fixes #519 